### PR TITLE
Bind operators of Cartesian states

### DIFF
--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -143,8 +143,10 @@ void cartesian_state(py::module_& m) {
   c.def(double() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
+
   c.def(py::self += py::self);
   c.def(py::self + py::self);
+  c.def("__neg__", [](const CartesianState& self) -> CartesianState { return -self; });
   c.def(py::self -= py::self);
   c.def(py::self - py::self);
 
@@ -222,11 +224,27 @@ void cartesian_pose(py::module_& m) {
   c.def(py::self / double());
 
   c.def(py::self += py::self);
+  c.def("__iadd__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
+  c.def("__iadd__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__iadd__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self += CartesianState());
   c.def(py::self + py::self);
+  c.def("__add__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
+  c.def("__add__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__add__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self + CartesianState());
+  c.def("__neg__", [](const CartesianPose& self) -> CartesianPose { return -self; });
   c.def(py::self -= py::self);
+  c.def("__isub__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
+  c.def("__isub__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__isub__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self -= CartesianState());
   c.def(py::self - py::self);
+  c.def("__sub__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
+  c.def("__sub__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__sub__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
 
-  c.def(py::self / std::chrono::nanoseconds());
+  c.def(py::self - CartesianState());
 
   c.def("copy", &CartesianPose::copy, "Return a copy of the CartesianPose");
   c.def("data", &CartesianPose::data, "Returns the pose data as a vector");
@@ -282,11 +300,6 @@ void cartesian_twist(py::module_& m) {
   }
   c.def(std::string("get_orientation_coefficients").c_str(), [](const CartesianTwist&) -> void {}, "Deleted method from parent class.");
 
-  c.def(py::self += py::self);
-  c.def(py::self + py::self);
-  c.def(py::self -= py::self);
-  c.def(py::self - py::self);
-
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(py::self /= double());
@@ -298,6 +311,28 @@ void cartesian_twist(py::module_& m) {
   c.def(double() * py::self);
   c.def(std::chrono::nanoseconds() * py::self);
   c.def(Eigen::Matrix<double, 6, 6>() * py::self);
+
+  c.def(py::self += py::self);
+  c.def("__iadd__", [](const CartesianTwist& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianTwist' and 'state_representation.CartesianPose'"); });
+  c.def("__iadd__", [](const CartesianTwist& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianTwist' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__iadd__", [](const CartesianTwist& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianTwist' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self += CartesianState());
+  c.def(py::self + py::self);
+  c.def("__add__", [](const CartesianTwist& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianTwist' and 'state_representation.CartesianPose'"); });
+  c.def("__add__", [](const CartesianTwist& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianTwist' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__add__", [](const CartesianTwist& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianTwist' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self + CartesianState());
+  c.def("__neg__", [](const CartesianTwist& self) -> CartesianTwist { return -self; });
+  c.def(py::self -= py::self);
+  c.def("__isub__", [](const CartesianTwist& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianTwist' and 'state_representation.CartesianPose'"); });
+  c.def("__isub__", [](const CartesianTwist& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianTwist' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__isub__", [](const CartesianTwist& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianTwist' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self -= CartesianState());
+  c.def(py::self - py::self);
+  c.def("__sub__", [](const CartesianTwist& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianTwist' and 'state_representation.CartesianPose'"); });
+  c.def("__sub__", [](const CartesianTwist& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianTwist' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__sub__", [](const CartesianTwist& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianTwist' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self - CartesianState());
 
   c.def("clamp", &CartesianTwist::clamp, "Clamp inplace the magnitude of the twist to the values in argument", "max_linear"_a, "max_angular"_a, "linear_noise_ratio"_a=0, "angular_noise_ratio"_a=0);
   c.def("clamped", &CartesianTwist::clamped, "Return the clamped twist", "max_linear"_a, "max_angular"_a, "linear_noise_ratio"_a=0, "angular_noise_ratio"_a=0);
@@ -356,11 +391,6 @@ void cartesian_acceleration(py::module_& m) {
   }
   c.def(std::string("get_orientation_coefficients").c_str(), [](const CartesianAcceleration&) -> void {}, "Deleted method from parent class.");
 
-  c.def(py::self += py::self);
-  c.def(py::self + py::self);
-  c.def(py::self -= py::self);
-  c.def(py::self - py::self);
-
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(py::self /= double());
@@ -371,6 +401,28 @@ void cartesian_acceleration(py::module_& m) {
   c.def(double() * py::self);
   c.def(std::chrono::nanoseconds() * py::self);
   c.def(Eigen::Matrix<double, 6, 6>() * py::self);
+
+  c.def(py::self += py::self);
+  c.def("__iadd__", [](const CartesianAcceleration& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianPose'"); });
+  c.def("__iadd__", [](const CartesianAcceleration& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianTwist'"); });
+  c.def("__iadd__", [](const CartesianAcceleration& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self += CartesianState());
+  c.def(py::self + py::self);
+  c.def("__add__", [](const CartesianAcceleration& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianPose'"); });
+  c.def("__add__", [](const CartesianAcceleration& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianTwist'"); });
+  c.def("__add__", [](const CartesianAcceleration& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self + CartesianState());
+  c.def("__neg__", [](const CartesianAcceleration& self) -> CartesianAcceleration { return -self; });
+  c.def(py::self -= py::self);
+  c.def("__isub__", [](const CartesianAcceleration& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianPose'"); });
+  c.def("__isub__", [](const CartesianAcceleration& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianTwist'"); });
+  c.def("__isub__", [](const CartesianAcceleration& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self -= CartesianState());
+  c.def(py::self - py::self);
+  c.def("__sub__", [](const CartesianAcceleration& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianPose'"); });
+  c.def("__sub__", [](const CartesianAcceleration& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianTwist'"); });
+  c.def("__sub__", [](const CartesianAcceleration& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self - CartesianState());
 
   c.def("clamp", &CartesianAcceleration::clamp, "Clamp inplace the magnitude of the acceleration to the values in argument", "max_linear"_a, "max_angular"_a, "linear_noise_ratio"_a=0, "angular_noise_ratio"_a=0);
   c.def("clamped", &CartesianAcceleration::clamped, "Return the clamped acceleration", "max_linear"_a, "max_angular"_a, "linear_noise_ratio"_a=0, "angular_noise_ratio"_a=0);
@@ -428,16 +480,33 @@ void cartesian_wrench(py::module_& m) {
   }
   c.def(std::string("get_orientation_coefficients").c_str(), [](const CartesianWrench&) -> void {}, "Deleted method from parent class.");
 
-  c.def(py::self += py::self);
-  c.def(py::self + py::self);
-  c.def(py::self -= py::self);
-  c.def(py::self - py::self);
-
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
+
+  c.def(py::self += py::self);
+  c.def("__iadd__", [](const CartesianWrench& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianWrench' and 'state_representation.CartesianPose'"); });
+  c.def("__iadd__", [](const CartesianWrench& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianWrench' and 'state_representation.CartesianTwist'"); });
+  c.def("__iadd__", [](const CartesianWrench& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianWrench' and 'state_representation.CartesianAcceleration'"); });
+  c.def(py::self += CartesianState());
+  c.def(py::self + py::self);
+  c.def("__add__", [](const CartesianWrench& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianWrench' and 'state_representation.CartesianPose'"); });
+  c.def("__add__", [](const CartesianWrench& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianWrench' and 'state_representation.CartesianTwist'"); });
+  c.def("__add__", [](const CartesianWrench& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for +: 'state_representation.CartesianWrench' and 'state_representation.CartesianAcceleration'"); });
+  c.def(py::self + CartesianState());
+  c.def("__neg__", [](const CartesianWrench& self) -> CartesianWrench { return -self; });
+  c.def(py::self -= py::self);
+  c.def("__isub__", [](const CartesianWrench& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianWrench' and 'state_representation.CartesianPose'"); });
+  c.def("__isub__", [](const CartesianWrench& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianWrench' and 'state_representation.CartesianTwist'"); });
+  c.def("__isub__", [](const CartesianWrench& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -=: 'state_representation.CartesianWrench' and 'state_representation.CartesianAcceleration'"); });
+  c.def(py::self -= CartesianState());
+  c.def(py::self - py::self);
+  c.def("__sub__", [](const CartesianWrench& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianWrench' and 'state_representation.CartesianPose'"); });
+  c.def("__sub__", [](const CartesianWrench& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianWrench' and 'state_representation.CartesianTwist'"); });
+  c.def("__sub__", [](const CartesianWrench& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for -: 'state_representation.CartesianWrench' and 'state_representation.CartesianAcceleration'"); });
+  c.def(py::self - CartesianState());
 
   c.def("clamp", &CartesianWrench::clamp, "Clamp inplace the magnitude of the wrench to the values in argument", "max_force"_a, "max_torque"_a, "force_noise_ratio"_a=0, "torque_noise_ratio"_a=0);
   c.def("clamped", &CartesianWrench::clamped, "Return the clamped wrench", "max_force"_a, "max_torque"_a, "force_noise_ratio"_a=0, "torque_noise_ratio"_a=0);

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -141,6 +141,7 @@ void cartesian_state(py::module_& m) {
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
+  c.def(py::self * Eigen::Vector3d());
   c.def(py::self /= double());
   c.def(py::self / double());
 
@@ -212,16 +213,22 @@ void cartesian_pose(py::module_& m) {
   }
 
   c.def(py::self *= py::self);
+  c.def("__imul__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
+  c.def("__imul__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
+  c.def("__imul__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
+  c.def(py::self *= CartesianState());
   c.def(py::self * py::self);
-  c.def(py::self * CartesianState());
   c.def(py::self * CartesianTwist());
+  c.def(py::self * CartesianAcceleration());
   c.def(py::self * CartesianWrench());
-  c.def(py::self * Eigen::Vector3d());
+  c.def(py::self * CartesianState());
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
+
+  c.def(py::self / std::chrono::nanoseconds());
 
   c.def(py::self += py::self);
   c.def("__iadd__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
@@ -302,15 +309,14 @@ void cartesian_twist(py::module_& m) {
 
   c.def(py::self *= double());
   c.def(py::self * double());
+  c.def(double() * py::self);
+  c.def("__mul__", [](const CartesianTwist& self, const Eigen::Matrix<double, 6, 6>& other) -> void { throw py::type_error("unsupported operand type(s) for *: 'state_representation.CartesianTwist' and 'numpy.ndarray'"); });
+  c.def(Eigen::Matrix<double, 6, 6>() * py::self);
+  c.def(py::self * std::chrono::nanoseconds());
+  c.def(std::chrono::nanoseconds() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
-  c.def(py::self *= Eigen::Matrix<double, 6, 6>());
-  c.def(py::self * std::chrono::nanoseconds());
   c.def(py::self / std::chrono::nanoseconds());
-
-  c.def(double() * py::self);
-  c.def(std::chrono::nanoseconds() * py::self);
-  c.def(Eigen::Matrix<double, 6, 6>() * py::self);
 
   c.def(py::self += py::self);
   c.def("__iadd__", [](const CartesianTwist& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianTwist' and 'state_representation.CartesianPose'"); });
@@ -393,14 +399,13 @@ void cartesian_acceleration(py::module_& m) {
 
   c.def(py::self *= double());
   c.def(py::self * double());
+  c.def(double() * py::self);
+  c.def("__mul__", [](const CartesianAcceleration& self, const Eigen::Matrix<double, 6, 6>& other) -> void { throw py::type_error("unsupported operand type(s) for *: 'state_representation.CartesianAcceleration' and 'numpy.ndarray'"); });
+  c.def(Eigen::Matrix<double, 6, 6>() * py::self);
+  c.def(py::self * std::chrono::nanoseconds());
+  c.def(std::chrono::nanoseconds() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
-  c.def(py::self *= Eigen::Matrix<double, 6, 6>());
-  c.def(py::self * std::chrono::nanoseconds());
-
-  c.def(double() * py::self);
-  c.def(std::chrono::nanoseconds() * py::self);
-  c.def(Eigen::Matrix<double, 6, 6>() * py::self);
 
   c.def(py::self += py::self);
   c.def("__iadd__", [](const CartesianAcceleration& self, const CartesianPose& other) -> void { throw py::type_error("unsupported operand type(s) for +=: 'state_representation.CartesianAcceleration' and 'state_representation.CartesianPose'"); });
@@ -483,6 +488,8 @@ void cartesian_wrench(py::module_& m) {
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
+  c.def("__mul__", [](const CartesianWrench& self, const Eigen::Matrix<double, 6, 6>& other) -> void { throw py::type_error("unsupported operand type(s) for *: 'state_representation.CartesianWrench' and 'numpy.ndarray'"); });
+  c.def(Eigen::Matrix<double, 6, 6>() * py::self);
   c.def(py::self /= double());
   c.def(py::self / double());
 

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -7,8 +7,6 @@
 void bind_jacobian(py::module_& m) {
   py::class_<Jacobian, std::shared_ptr<Jacobian>, State> c(m, "Jacobian");
 
-  c.def_property_readonly_static("__array_priority__", [](py::object) { return 10000; });
-
   c.def(py::init(), "Empty constructor for a Jacobian");
   c.def(py::init<const std::string&, unsigned int, const std::string&, const std::string&>(),
         "Constructor with name, number of joints, frame name and reference frame provided",

--- a/python/source/state_representation/bind_state.cpp
+++ b/python/source/state_representation/bind_state.cpp
@@ -28,6 +28,7 @@ void state_type(py::module_& m) {
 
 void state(py::module_& m) {
   py::class_<State, std::shared_ptr<State>> c(m, "State");
+  c.def_property_readonly_static("__array_priority__", [](py::object) { return 10000; });
 
   c.def(py::init(), "Empty constructor");
   c.def(py::init<const std::string&>(), "Constructor with name specification", "name"_a);

--- a/python/test/state_representation/space/cartesian/test_cartesian_state.py
+++ b/python/test/state_representation/space/cartesian/test_cartesian_state.py
@@ -6,6 +6,7 @@ from pyquaternion.quaternion import Quaternion
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from state_representation import State, CartesianState, StateType, CartesianStateVariable, CartesianPose, \
     CartesianTwist, CartesianAcceleration, CartesianWrench
+from datetime import timedelta
 
 from ..test_spatial_state import SPATIAL_STATE_METHOD_EXPECTS
 from ...test_state import STATE_METHOD_EXPECTS
@@ -461,6 +462,123 @@ class TestCartesianState(unittest.TestCase):
         self.assertFalse(empty.is_empty())
         self.assertTrue(empty)
 
+    def test_state_multiplication_operators(self):
+        state = CartesianState.Random("world")
+        pose = CartesianPose.Random("world")
+        twist = CartesianTwist.Random("world")
+        acceleration = CartesianAcceleration.Random("world")
+        wrench = CartesianWrench.Random("world")
+
+        # CartesianState multiplied with any derived stays a CartesianState
+        res = state * state
+        self.assertIsInstance(res, CartesianState)
+        res = state * pose
+        self.assertIsInstance(res, CartesianState)
+        res = state * twist
+        self.assertIsInstance(res, CartesianState)
+        res = state * acceleration
+        self.assertIsInstance(res, CartesianState)
+        res = state * wrench
+        self.assertIsInstance(res, CartesianState)
+
+        # CartesianPose multiplied with any derived type is defined by the right hand type
+        res = pose * state
+        self.assertIsInstance(res, CartesianState)
+        res = pose * pose
+        self.assertIsInstance(res, CartesianPose)
+        res = pose * twist
+        self.assertIsInstance(res, CartesianTwist)
+        res = pose * acceleration
+        self.assertIsInstance(res, CartesianAcceleration)
+        res = pose * wrench
+        self.assertIsInstance(res, CartesianWrench)
+
+        with self.assertRaises(TypeError):
+            res = twist * state
+        with self.assertRaises(TypeError):
+            res = twist * pose
+        with self.assertRaises(TypeError):
+            res = twist * twist
+        with self.assertRaises(TypeError):
+            res = twist * acceleration
+        with self.assertRaises(TypeError):
+            res = twist * wrench
+        with self.assertRaises(TypeError):
+            res = acceleration * state
+        with self.assertRaises(TypeError):
+            res = acceleration * pose
+        with self.assertRaises(TypeError):
+            res = acceleration * twist
+        with self.assertRaises(TypeError):
+            res = acceleration * acceleration
+        with self.assertRaises(TypeError):
+            res = acceleration * wrench
+        with self.assertRaises(TypeError):
+            res = wrench * state
+        with self.assertRaises(TypeError):
+            res = wrench * pose
+        with self.assertRaises(TypeError):
+            res = wrench * twist
+        with self.assertRaises(TypeError):
+            res = wrench * acceleration
+        with self.assertRaises(TypeError):
+            res = wrench * wrench
+
+        state *= state
+        self.assertIsInstance(state, CartesianState)
+        state *= pose
+        self.assertIsInstance(state, CartesianState)
+        state *= twist
+        self.assertIsInstance(state, CartesianState)
+        state *= acceleration
+        self.assertIsInstance(state, CartesianState)
+        state *= wrench
+        self.assertIsInstance(state, CartesianState)
+
+        pose *= state
+        self.assertIsInstance(pose, CartesianPose)
+        pose *= pose
+        self.assertIsInstance(pose, CartesianPose)
+        with self.assertRaises(TypeError):
+            pose *= twist
+        with self.assertRaises(TypeError):
+            pose *= acceleration
+        with self.assertRaises(TypeError):
+            pose *= wrench
+
+        with self.assertRaises(TypeError):
+            twist *= state
+        with self.assertRaises(TypeError):
+            twist *= pose
+        with self.assertRaises(TypeError):
+            twist *= twist
+        with self.assertRaises(TypeError):
+            twist *= acceleration
+        with self.assertRaises(TypeError):
+            twist *= wrench
+
+        with self.assertRaises(TypeError):
+            acceleration *= state
+        with self.assertRaises(TypeError):
+            acceleration *= pose
+        with self.assertRaises(TypeError):
+            acceleration *= twist
+        with self.assertRaises(TypeError):
+            acceleration *= acceleration
+        with self.assertRaises(TypeError):
+            acceleration *= wrench
+
+        with self.assertRaises(TypeError):
+            wrench *= state
+        with self.assertRaises(TypeError):
+            wrench *= pose
+        with self.assertRaises(TypeError):
+            wrench *= twist
+        with self.assertRaises(TypeError):
+            wrench *= acceleration
+        with self.assertRaises(TypeError):
+            wrench *= wrench
+
     def test_state_addition_operators(self):
         state = CartesianState.Random("test")
         pose = CartesianPose.Random("test")
@@ -696,6 +814,110 @@ class TestCartesianState(unittest.TestCase):
             wrench -= twist
         with self.assertRaises(TypeError):
             wrench -= acceleration
+
+    def test_multiplication_operators(self):
+        state = CartesianState.Random("world")
+        pose = CartesianPose.Random("world")
+        twist = CartesianTwist.Random("world")
+        acceleration = CartesianAcceleration.Random("world")
+        wrench = CartesianWrench.Random("world")
+
+        # state
+        state *= 3.0
+        self.assertIsInstance(state, CartesianState)
+        result = state * 3.0
+        self.assertIsInstance(result, CartesianState)
+        result = 3.0 * state
+        self.assertIsInstance(result, CartesianState)
+        arr = np.array([1.1, 2.2, 3.3])
+        result = state * np.array([1.1, 2.2, 3.3])
+        self.assertIsInstance(result, type(arr))
+        self.assertTrue(len(result) == 3)
+        state /= 2.0
+        self.assertIsInstance(state, CartesianState)
+        result = state / 2.0
+        self.assertIsInstance(result, CartesianState)
+
+        # pose
+        pose *= 3.0
+        self.assertIsInstance(pose, CartesianPose)
+        result = pose * 3.0
+        self.assertIsInstance(result, CartesianPose)
+        result = 3.0 * pose
+        self.assertIsInstance(result, CartesianPose)
+        result = pose / 2.0
+        self.assertIsInstance(result, CartesianPose)
+        result = pose / timedelta(seconds=1)
+        self.assertIsInstance(result, CartesianTwist)
+        pose /= 2.0
+        self.assertIsInstance(pose, CartesianPose)
+
+        # twist
+        twist *= 3.0
+        self.assertIsInstance(twist, CartesianTwist)
+        result = twist * 3.0
+        self.assertIsInstance(result, CartesianTwist)
+        result = 3.0 * twist
+        self.assertIsInstance(result, CartesianTwist)
+        mat = np.random.rand(6, 6)
+        result = mat * twist
+        self.assertIsInstance(result, CartesianTwist)
+        with self.assertRaises(TypeError):
+            twist *= mat
+        with self.assertRaises(TypeError):
+            result = twist * mat
+        result = twist * timedelta(seconds=1)
+        self.assertIsInstance(result, CartesianPose)
+        result = timedelta(seconds=1) * twist
+        self.assertIsInstance(result, CartesianPose)
+        twist /= 3.0
+        self.assertIsInstance(twist, CartesianTwist)
+        result = twist / 3.0
+        self.assertIsInstance(result, CartesianTwist)
+        result = twist / timedelta(seconds=1)
+        self.assertIsInstance(result, CartesianAcceleration)
+
+        # acceleration
+        acceleration *= 3.0
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        result = acceleration * 3.0
+        self.assertIsInstance(result, CartesianAcceleration)
+        result = 3.0 * acceleration
+        self.assertIsInstance(result, CartesianAcceleration)
+        mat = np.random.rand(6, 6)
+        result = mat * acceleration
+        self.assertIsInstance(result, CartesianAcceleration)
+        with self.assertRaises(TypeError):
+            acceleration *= mat
+        with self.assertRaises(TypeError):
+            result = acceleration * mat
+        result = acceleration * timedelta(seconds=1)
+        self.assertIsInstance(result, CartesianTwist)
+        result = timedelta(seconds=1) * acceleration
+        self.assertIsInstance(result, CartesianTwist)
+        acceleration /= 3.0
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        result = acceleration / 3.0
+        self.assertIsInstance(result, CartesianAcceleration)
+
+        # wrench
+        wrench *= 3.0
+        self.assertIsInstance(wrench, CartesianWrench)
+        result = wrench * 3.0
+        self.assertIsInstance(result, CartesianWrench)
+        result = 3.0 * wrench
+        self.assertIsInstance(result, CartesianWrench)
+        mat = np.random.rand(6, 6)
+        result = mat * wrench
+        self.assertIsInstance(result, CartesianWrench)
+        with self.assertRaises(TypeError):
+            wrench *= mat
+        with self.assertRaises(TypeError):
+            result = wrench * mat
+        wrench /= 3.0
+        self.assertIsInstance(wrench, CartesianWrench)
+        result = wrench / 3.0
+        self.assertIsInstance(result, CartesianWrench)
 
 
 if __name__ == '__main__':

--- a/python/test/state_representation/space/cartesian/test_cartesian_state.py
+++ b/python/test/state_representation/space/cartesian/test_cartesian_state.py
@@ -4,7 +4,8 @@ import copy
 import numpy as np
 from pyquaternion.quaternion import Quaternion
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from state_representation import State, CartesianState, StateType, CartesianStateVariable
+from state_representation import State, CartesianState, StateType, CartesianStateVariable, CartesianPose, \
+    CartesianTwist, CartesianAcceleration, CartesianWrench
 
 from ..test_spatial_state import SPATIAL_STATE_METHOD_EXPECTS
 from ...test_state import STATE_METHOD_EXPECTS
@@ -459,6 +460,242 @@ class TestCartesianState(unittest.TestCase):
         empty.set_data(CartesianState().Random("test").data())
         self.assertFalse(empty.is_empty())
         self.assertTrue(empty)
+
+    def test_state_addition_operators(self):
+        state = CartesianState.Random("test")
+        pose = CartesianPose.Random("test")
+        twist = CartesianTwist.Random("test")
+        acceleration = CartesianAcceleration.Random("test")
+        wrench = CartesianWrench.Random("test")
+
+        res = pose + pose
+        self.assertIsInstance(res, CartesianPose)
+        res = state + pose
+        self.assertIsInstance(res, CartesianState)
+        res = pose + state
+        self.assertIsInstance(res, CartesianState)
+
+        res = twist + twist
+        self.assertIsInstance(res, CartesianTwist)
+        res = state + twist
+        self.assertIsInstance(res, CartesianState)
+        res = twist + state
+        self.assertIsInstance(res, CartesianState)
+
+        res = acceleration + acceleration
+        self.assertIsInstance(res, CartesianAcceleration)
+        res = state + acceleration
+        self.assertIsInstance(res, CartesianState)
+        res = acceleration + state
+        self.assertIsInstance(res, CartesianState)
+
+        res = wrench + wrench
+        self.assertIsInstance(res, CartesianWrench)
+        res = state + wrench
+        self.assertIsInstance(res, CartesianState)
+        res = wrench + state
+        self.assertIsInstance(res, CartesianState)
+
+        with self.assertRaises(TypeError):
+            res = pose + twist
+        with self.assertRaises(TypeError):
+            res = pose + acceleration
+        with self.assertRaises(TypeError):
+            res = pose + wrench
+
+        with self.assertRaises(TypeError):
+            res = twist + pose
+        with self.assertRaises(TypeError):
+            res = twist + acceleration
+        with self.assertRaises(TypeError):
+            res = twist + wrench
+
+        with self.assertRaises(TypeError):
+            res = acceleration + pose
+        with self.assertRaises(TypeError):
+            res = acceleration + twist
+        with self.assertRaises(TypeError):
+            res = acceleration + wrench
+
+        with self.assertRaises(TypeError):
+            res = wrench + pose
+        with self.assertRaises(TypeError):
+            res = wrench + twist
+        with self.assertRaises(TypeError):
+            res = wrench + acceleration
+
+        state += state
+        self.assertIsInstance(state, CartesianState)
+        state += pose
+        self.assertIsInstance(state, CartesianState)
+        state += twist
+        self.assertIsInstance(state, CartesianState)
+        state += acceleration
+        self.assertIsInstance(state, CartesianState)
+        state += wrench
+        self.assertIsInstance(state, CartesianState)
+
+        pose += state
+        self.assertIsInstance(pose, CartesianPose)
+        pose += pose
+        self.assertIsInstance(pose, CartesianPose)
+        with self.assertRaises(TypeError):
+            pose += twist
+        with self.assertRaises(TypeError):
+            pose += acceleration
+        with self.assertRaises(TypeError):
+            pose += wrench
+
+        twist += state
+        self.assertIsInstance(twist, CartesianTwist)
+        twist += twist
+        self.assertIsInstance(twist, CartesianTwist)
+        with self.assertRaises(TypeError):
+            twist += pose
+        with self.assertRaises(TypeError):
+            twist += acceleration
+        with self.assertRaises(TypeError):
+            twist += wrench
+
+        acceleration += state
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        acceleration += acceleration
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        with self.assertRaises(TypeError):
+            acceleration += pose
+        with self.assertRaises(TypeError):
+            acceleration += twist
+        with self.assertRaises(TypeError):
+            acceleration += wrench
+
+        wrench += state
+        self.assertIsInstance(wrench, CartesianWrench)
+        wrench += wrench
+        self.assertIsInstance(wrench, CartesianWrench)
+        with self.assertRaises(TypeError):
+            wrench += pose
+        with self.assertRaises(TypeError):
+            wrench += twist
+        with self.assertRaises(TypeError):
+            wrench += acceleration
+
+    def test_state_subtraction_operators(self):
+        state = CartesianState.Random("test")
+        pose = CartesianPose.Random("test")
+        twist = CartesianTwist.Random("test")
+        acceleration = CartesianAcceleration.Random("test")
+        wrench = CartesianWrench.Random("test")
+
+        res = pose - pose
+        self.assertIsInstance(res, CartesianPose)
+        res = state - pose
+        self.assertIsInstance(res, CartesianState)
+        res = pose - state
+        self.assertIsInstance(res, CartesianState)
+
+        res = twist - twist
+        self.assertIsInstance(res, CartesianTwist)
+        res = state - twist
+        self.assertIsInstance(res, CartesianState)
+        res = twist - state
+        self.assertIsInstance(res, CartesianState)
+
+        res = acceleration - acceleration
+        self.assertIsInstance(res, CartesianAcceleration)
+        res = state - acceleration
+        self.assertIsInstance(res, CartesianState)
+        res = acceleration - state
+        self.assertIsInstance(res, CartesianState)
+
+        res = wrench - wrench
+        self.assertIsInstance(res, CartesianWrench)
+        res = state - wrench
+        self.assertIsInstance(res, CartesianState)
+        res = wrench - state
+        self.assertIsInstance(res, CartesianState)
+
+        with self.assertRaises(TypeError):
+            res = pose - twist
+        with self.assertRaises(TypeError):
+            res = pose - acceleration
+        with self.assertRaises(TypeError):
+            res = pose - wrench
+
+        with self.assertRaises(TypeError):
+            res = twist - pose
+        with self.assertRaises(TypeError):
+            res = twist - acceleration
+        with self.assertRaises(TypeError):
+            res = twist - wrench
+
+        with self.assertRaises(TypeError):
+            res = acceleration - pose
+        with self.assertRaises(TypeError):
+            res = acceleration - twist
+        with self.assertRaises(TypeError):
+            res = acceleration - wrench
+
+        with self.assertRaises(TypeError):
+            res = wrench - pose
+        with self.assertRaises(TypeError):
+            res = wrench - twist
+        with self.assertRaises(TypeError):
+            res = wrench - acceleration
+
+        state -= state
+        self.assertIsInstance(state, CartesianState)
+        state -= pose
+        self.assertIsInstance(state, CartesianState)
+        state -= twist
+        self.assertIsInstance(state, CartesianState)
+        state -= acceleration
+        self.assertIsInstance(state, CartesianState)
+        state -= wrench
+        self.assertIsInstance(state, CartesianState)
+
+        pose -= state
+        self.assertIsInstance(pose, CartesianPose)
+        pose -= pose
+        self.assertIsInstance(pose, CartesianPose)
+        with self.assertRaises(TypeError):
+            pose -= twist
+        with self.assertRaises(TypeError):
+            pose -= acceleration
+        with self.assertRaises(TypeError):
+            pose -= wrench
+
+        twist -= state
+        self.assertIsInstance(twist, CartesianTwist)
+        twist -= twist
+        self.assertIsInstance(twist, CartesianTwist)
+        with self.assertRaises(TypeError):
+            twist -= pose
+        with self.assertRaises(TypeError):
+            twist -= acceleration
+        with self.assertRaises(TypeError):
+            twist -= wrench
+
+        acceleration -= state
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        acceleration -= acceleration
+        self.assertIsInstance(acceleration, CartesianAcceleration)
+        with self.assertRaises(TypeError):
+            acceleration -= pose
+        with self.assertRaises(TypeError):
+            acceleration -= twist
+        with self.assertRaises(TypeError):
+            acceleration -= wrench
+
+        wrench -= state
+        self.assertIsInstance(wrench, CartesianWrench)
+        wrench -= wrench
+        self.assertIsInstance(wrench, CartesianWrench)
+        with self.assertRaises(TypeError):
+            wrench -= pose
+        with self.assertRaises(TypeError):
+            wrench -= twist
+        with self.assertRaises(TypeError):
+            wrench -= acceleration
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #18 

<!-- Required: explain how the PR addresses the parent issue -->
By explicitly adding and "deleting" (means: adding the operator and throw a type error inside), we can ensure that operations on states yield the same type of object as it would in C++. I find this quite important, even though Python is not a typed language.

The big part of the changes come from tests, that are mostly just the equivalent of the C++ tests.

## Supporting information
- As far as I understand, there might exist several possible operators for a certain object (i.e. when `__mul__` doesn't exist, it just uses `__rmul__` from the other object. Moreover, the order of these definitions matters quite a lot because the interpreter just goes through all possible operators one by one. That's why you see stuff like
  ```
  c.def("__imul__", [](const CartesianPose& self, const CartesianTwist& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianTwist'"); });
  c.def("__imul__", [](const CartesianPose& self, const CartesianAcceleration& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianAcceleration'"); });
  c.def("__imul__", [](const CartesianPose& self, const CartesianWrench& other) -> void { throw py::type_error("unsupported operand type(s) for *=: 'state_representation.CartesianPose' and 'state_representation.CartesianWrench'"); });
  c.def(py::self *= CartesianState());
  ```
  where the *= operator is first deleted for all derived classes and then added back for the Cartesian state only.
- The necessity for `
  c.def_property_readonly_static("__array_priority__", [](py::object) { return 10000; });` is described [here](https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_priority__)

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 30 minutes
Review by commit

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->