### PR TITLE
feat(robot-model): improve inverse kinematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release Versions
 - fix(robot-model): improve ik performance (#205)
 - fix(robot-model): kinematics tests (#207)
 - feat: add integrate and differentiate methods to Cartesian types (#209)
+- feat(robot-model): improve inverse kinematics (#208)
 
 ## 9.0.1
 
@@ -36,7 +37,6 @@ It is now possible to convert `CartesianStateVariable` and `JointStateVariable`s
 - feat(state-representation): add utilities for CartesianStateVariable (#195, #201)
 - feat(state-representation): add utilities for JointStateVariable (#197, #201)
 - feat(robot-model): add clamp_in_range function for individual JointStateVariable (#194)
-- feat(robot-model): improve inverse kinematics (#208)
   
 ## 9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ It is now possible to convert `CartesianStateVariable` and `JointStateVariable`s
 - feat(state-representation): add utilities for CartesianStateVariable (#195, #201)
 - feat(state-representation): add utilities for JointStateVariable (#197, #201)
 - feat(robot-model): add clamp_in_range function for individual JointStateVariable (#194)
+- feat(robot-model): improve inverse kinematics (#208)
   
 ## 9.0.0
 

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -311,7 +311,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
   InverseKinematicsParameters param = InverseKinematicsParameters();
   param.tolerance = tol;
 
-  std::size_t num_samples = 100;
+  std::size_t num_samples = 1000;
   for (const auto& urdf : std::vector<std::string>{"panda_arm.urdf", "ur5e.urdf", "xarm.urdf"}) {
     auto robot = std::make_unique<Model>("robot", std::string(TEST_FIXTURES) + urdf);
     state_representation::JointPositions config("robot", robot->get_joint_frames());
@@ -323,15 +323,13 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
     for (std::size_t i = 0; i < num_samples; ++i) {
       config.set_positions(pinocchio::randomConfiguration(robot->get_pinocchio_model()));
       auto reference = robot->forward_kinematics(config);
+      start_time = std::chrono::system_clock::now();
       try {
-        start_time = std::chrono::system_clock::now();
         robot->inverse_kinematics(reference, param);
-        diff = std::chrono::system_clock::now() - start_time;
-        total_time += diff.count();
         ++success;
-      } catch (const std::exception&) {
-        continue;
-      }
+      } catch (const std::exception&) {}
+      diff = std::chrono::system_clock::now() - start_time;
+      total_time += diff.count();
     }
     std::cout << urdf << ": found " << success << " solutions (" << 100.0 * success / num_samples
             << "%) with an average of " << total_time / num_samples << " secs per sample" << std::endl;


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #205

<!-- Required: explain how the PR addresses the parent issue -->
Where do I start. This PR improves the IK of the robot model by mixing the existing CWLN method with the [CLIK example from pinocchio](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/md_doc_b_examples_d_inverse_kinematics.html). Additionally, it allows the function to try to find a solution 3 times, starting at different random configurations. I believe that two of the main problems that the previous implementation had was that
1. It would clamp the joint positions at the joint limits at each configuration. I can observe that intermediate joint configurations (during the search) can be outside the limits and will then come back for the final solution.
2. Pinocchio has this particular differentiation between "frames" (links + joints) and "joints" (just joints). Previously, we would calculate the Jacobian for a certain frame whereas now, I infer the parent joint of the desired frame and do the calculations with the `JointJacobian`. This seems to work better.

**Important:** For me, this PR does not really solve the problem of having a general, robust, fast IK algorithm available. What it does is it improves the existing one by so much and in a non-breaking way that I want to get it in until we find the time to really ask ourselves what changes we want to make in the robot library. In particular, regarding this IK algorithm:
- The "3" retries is a magic number and should be one of the parameters
- The equations don't fully correspond to the paper mentioned in https://github.com/epfl-lasa/control-libraries/pull/46 - but they have worked and continue to work somehow
- The ik might throw a runtime error, but it should rather throw a robot_model exception

## Supporting information
### Benchmark results
For benchmarking, I compared the control libraries IK (CL) with either 1 or 3 retries against KDL and [TRAC IK](https://github.com/aprotyas/trac_ik) which uses a nonlinear optimization to solve the IK. We can see that TRAC outperforms CL by a slight margin, but is also slightly slower. This is a fair tradeoff. Since TRAC depends on KDL, we can't easily integrate it but we could potentially reimplement it with pinocchio in the future.

#### % success, 10000 samples
|     | UR5e | xArm | Panda
| -------- | ------- | -------- | ------- |
| KDL  | 31.57 | 27.25 | 62.11
| TRAC | 99.88 | 99.84 | 99.79
| CL old | ~57 | ~63 | ~74
| CL  | 98.03 | 97.16 | 87.77
| CL 3 tries  | 99.66 | 98.49 | 96.56

#### time per sample in milliseconds, 10000 samples
|     | UR5e | xArm | Panda
| -------- | ------- | -------- | ------- |
| KDL  | 3.48 | 3.69 | 2.08
| TRAC | 0.35 | 0.53 | 0.42
| CL old | 0.25 | 0.15 | 0.35
| CL  | 0.11 | 0.13 | 0.55
| CL 3 tries  | 0.15 | 0.17 | 0.87

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 15 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->