### PR TITLE
feat: add integrate method with offset to Cartesian twist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@ Release Versions
 ## Upcoming changes
 
 - fix(robot-model): improve ik performance (#205)
-- fix(robot-model): kinematics tests (#207)
 - feat: add integrate and differentiate methods to Cartesian and joint types (#193)
-- feat(robot-model): improve inverse kinematics (#208)
 
 ## 9.0.1
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -375,9 +375,15 @@ void cartesian_twist(py::module_& m) {
   c.def("integrate", [](const CartesianTwist &twist, double dt) -> CartesianPose {
     return twist.integrate(dt);
   }, "Integrate a Cartesian twist over a time period in seconds", "dt"_a);
+  c.def("integrate", [](const CartesianTwist &twist, double dt, const CartesianPose &initial_pose) -> CartesianPose {
+    return twist.integrate(dt, initial_pose);
+  }, "Integrate a Cartesian twist over a time period in seconds from an initial Cartesian pose", "dt"_a, "initial_pose"_a);
   c.def("integrate", [](const CartesianTwist &twist, const std::chrono::nanoseconds& dt) -> CartesianPose {
     return twist.integrate(dt);
   }, "Integrate a Cartesian twist over a time period", "dt"_a);
+  c.def("integrate", [](const CartesianTwist &twist, const std::chrono::nanoseconds& dt, const CartesianPose &initial_pose) -> CartesianPose {
+    return twist.integrate(dt, initial_pose);
+  }, "Integrate a Cartesian twist over a time period from an initial Cartesian pose", "dt"_a, "initial_pose"_a);
   c.def("inverse", &CartesianTwist::inverse, "Compute the inverse of the current CartesianTwist");
   c.def("set_data", py::overload_cast<const Eigen::VectorXd&>(&CartesianTwist::set_data), "Set the twist data from a vector", "data"_a);
   c.def("set_data", py::overload_cast<const std::vector<double>&>(&CartesianTwist::set_data), "Set the twist data from a list", "data"_a);

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -218,10 +218,30 @@ public:
 
   /**
    * @brief Integrate the Cartesian twist over a time period
+   * @details This method adds the integrated Cartesian twist to the provided initial pose by respecting the
+   * non-commutativity of the Cartesian pose: a_Result_b = a_InitialPose_b + a_Twist_b * dt
+   * @param dt The time period used for integration in seconds
+   * @param initial_pose The initial pose that should be added to the integration result
+   * @return The resulting Cartesian pose after integration
+   */
+  CartesianPose integrate(double dt, const CartesianPose& initial_pose) const;
+
+  /**
+   * @brief Integrate the Cartesian twist over a time period
    * @param dt The time period used for integration
    * @return The resulting Cartesian pose after integration
    */
   CartesianPose integrate(const std::chrono::nanoseconds& dt) const;
+
+  /**
+   * @brief Integrate the Cartesian twist over a time period
+   * @details This method adds the integrated Cartesian twist to the provided initial pose by respecting the
+   * non-commutativity of the Cartesian pose: a_Result_b = a_InitialPose_b + a_Twist_b * dt
+   * @param dt The time period used for integration
+   * @param initial_pose The initial pose that should be added to the integration result
+   * @return The resulting Cartesian pose after integration
+   */
+  CartesianPose integrate(const std::chrono::nanoseconds& dt, const CartesianPose& initial_pose) const;
 
   /**
    * @brief Compute the inverse of the current Cartesian twist

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -235,8 +235,7 @@ public:
 
   /**
    * @brief Integrate the Cartesian twist over a time period
-   * @details This method adds the integrated Cartesian twist to the provided initial pose by respecting the
-   * non-commutativity of the Cartesian pose: a_Result_b = a_InitialPose_b + a_Twist_b * dt
+   * @copydetails CartesianTwist::integrate(double, const CartesianPose&)
    * @param dt The time period used for integration
    * @param initial_pose The initial pose that should be added to the integration result
    * @return The resulting Cartesian pose after integration

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -1,5 +1,6 @@
 #include "state_representation/space/cartesian/CartesianTwist.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
+#include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 
 namespace state_representation {
 
@@ -126,9 +127,18 @@ CartesianPose CartesianTwist::integrate(double dt) const {
   return displacement;
 }
 
+CartesianPose CartesianTwist::integrate(double dt, const CartesianPose& initial_pose) const {
+  return initial_pose + this->integrate(dt);
+}
+
 CartesianPose CartesianTwist::integrate(const std::chrono::nanoseconds& dt) const {
   // convert the dt to a double with the second as reference
   return this->integrate(dt.count() / 1e9);
+}
+
+CartesianPose CartesianTwist::integrate(const std::chrono::nanoseconds& dt, const CartesianPose& initial_pose) const {
+  // convert the dt to a double with the second as reference
+  return this->integrate(dt.count() / 1e9, initial_pose);
 }
 
 CartesianTwist CartesianTwist::inverse() const {

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
@@ -135,6 +135,10 @@ TEST(CartesianTwistTest, TestIntegrate) {
   EXPECT_EQ(res3.get_type(), StateType::CARTESIAN_POSE);
   EXPECT_TRUE(res3.get_position().isApprox(dt1 * twist.get_linear_velocity()));
   EXPECT_TRUE(res3.get_orientation().coeffs().isApprox(Eigen::Quaterniond(0, 1, 0, 0).coeffs()));
+  auto res4 = twist.integrate(dt1, res3);
+  EXPECT_EQ(res4.get_type(), StateType::CARTESIAN_POSE);
+  EXPECT_TRUE(res4.get_position().isApprox(2 * dt1 * twist.get_linear_velocity()));
+  EXPECT_TRUE(res4.get_orientation().coeffs().isApprox(Eigen::Quaterniond(-1, 0, 0, 0).coeffs()));
 
   twist.set_angular_velocity(Eigen::Vector3d(M_PI, 0, 0));
   CartesianPose pose(twist);


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- https://github.com/aica-technology/control-libraries/pull/210#pullrequestreview-2538896426

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding methods that also take an initial pose for the integration of a Cartesian twist. I didn't go with an argument that has a default value `CartesianPose()` because then it becomes complicated to know when the argument was not provided or the provided argument is empty and we should throw an exception.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->