### PR TITLE
feat: add trajectory class bindings and python tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release Versions
 - fix: unstable python test (#221)
 - feat: move up to C++20 (#220)
 - feat: split trajectory classes and implement Cartesian/JointState specializations (#216, #217, #223)
+- feat: add trajectory class bindings and python tests (#219)
 
 ## 9.1.0
 

--- a/python/include/state_representation_bindings.hpp
+++ b/python/include/state_representation_bindings.hpp
@@ -27,3 +27,4 @@ void bind_jacobian(py::module_& m);
 void bind_parameters(py::module_& m);
 void bind_geometry(py::module_& m);
 void bind_io_state(py::module_& m);
+void bind_trajectory(py::module_& m);

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -1,0 +1,157 @@
+#include "state_representation_bindings.hpp"
+
+#include <state_representation/trajectory/CartesianTrajectory.hpp>
+#include <state_representation/trajectory/JointTrajectory.hpp>
+#include <string>
+#include <type_traits>
+
+#include "parameter_container.hpp"
+#include "py_parameter_map.hpp"
+
+void trajectory_points(py::module_& m) {
+  // Cartesian trajectory point bindings
+  py::class_<CartesianTrajectoryPoint, std::shared_ptr<CartesianTrajectoryPoint>> ctp(m, "CartesianTrajectoryPoint");
+  ctp.def(py::init<>(), "Empty constructor");
+  ctp.def(
+      py::init<const CartesianState&, const std::chrono::nanoseconds&>(),
+      "Constructor from Cartesian state and duration"
+  );
+  ctp.def(
+      "to_cartesian_state", &CartesianTrajectoryPoint::to_cartesian_state,
+      "Convert the trajectory point to a Cartesian state", "reference_frame"_a
+  );
+
+  // Joint trajectory point bindings
+  py::class_<JointTrajectoryPoint, std::shared_ptr<JointTrajectoryPoint>> jtp(m, "JointTrajectoryPoint");
+  jtp.def(py::init<>(), "Empty constructor");
+  jtp.def(py::init<const JointState&, const std::chrono::nanoseconds&>(), "Constructor from joint state and duration");
+  jtp.def(
+      "to_joint_state", &JointTrajectoryPoint::to_joint_state, "Convert the trajectory point to a joint state",
+      "joint_names"_a
+  );
+}
+
+template<typename T>
+void trajectory_base(py::module_& m) {
+  std::string base_name;
+  if constexpr (std::is_same_v<T, CartesianTrajectoryPoint>) {
+    base_name = "CartesianTrajectoryBase";
+  } else if constexpr (std::is_same_v<T, JointTrajectoryPoint>) {
+    base_name = "JointTrajectoryBase";
+  } else {
+    static_assert(false, "Unsupported type for trajectory base");
+  }
+  py::class_<TrajectoryBase<T>, std::shared_ptr<TrajectoryBase<T>>, State> c(m, base_name.c_str());
+
+  c.def(
+      "get_duration", &TrajectoryBase<T>::get_duration, "Get the duration of the trajectory point at given index",
+      "index"_a
+  );
+  c.def("get_durations", &TrajectoryBase<T>::get_durations, "Get list of trajectory point durations");
+  c.def(
+      "get_time_from_start", &TrajectoryBase<T>::get_time_from_start,
+      "Get the time from start of the trajectory point at given index", "index"_a
+  );
+  c.def(
+      "get_times_from_start", &TrajectoryBase<T>::get_times_from_start, "Get list of trajectory point times from start"
+  );
+  c.def(
+      "get_trajectory_duration", &TrajectoryBase<T>::get_trajectory_duration, "Get the total duration of the trajectory"
+  );
+  c.def("get_size", &TrajectoryBase<T>::get_size, "Get number of points in trajectory");
+  c.def("delete_point", py::overload_cast<>(&TrajectoryBase<T>::delete_point), "Delete the last point from trajectory");
+  c.def(
+      "delete_point", py::overload_cast<unsigned int>(&TrajectoryBase<T>::delete_point),
+      "Delete the last point from trajectory", "index"_a
+  );
+  c.def("reset", &TrajectoryBase<T>::reset, "Reset trajectory");
+}
+
+template<typename StateT>
+void trajectory_derived(py::module_& m) {
+  using namespace state_representation;
+
+  std::string trajectory_type;
+  if constexpr (std::is_same_v<StateT, CartesianState>) {
+    trajectory_type = "CartesianTrajectory";
+  } else if constexpr (std::is_same_v<StateT, JointState>) {
+    trajectory_type = "JointTrajectory";
+  } else {
+    static_assert(false, "Unsupported type for trajectory derived");
+  }
+  using TrajectoryT =
+      typename std::conditional<std::is_same_v<StateT, CartesianState>, CartesianTrajectory, JointTrajectory>::type;
+  using PointT = typename std::conditional<
+      std::is_same_v<StateT, CartesianState>, CartesianTrajectoryPoint, JointTrajectoryPoint>::type;
+
+  // constructors
+  py::class_<TrajectoryT, std::shared_ptr<TrajectoryT>> c(
+      m, trajectory_type.c_str(), py::base<TrajectoryBase<PointT>>()
+  );
+
+  if constexpr (std::is_same_v<StateT, CartesianState>) {
+    c.def(py::init<>(), "Empty constructor");
+    c.def(
+        py::init<const std::string&, const std::string&>(), "Constructor with name and reference frame provided",
+        "name"_a, "reference_frame"_a = "world"
+    );
+  } else if constexpr (std::is_same_v<StateT, JointState>) {
+    c.def(py::init<const std::string&>(), "Constructor with optional name", "name"_a = "");
+  }
+  c.def(
+      py::init<const std::string&, const StateT&, const std::chrono::nanoseconds&>(),
+      "Constructor with name, initial point, and duration provided", "name"_a, "point"_a, "duration"_a
+  );
+  c.def(
+      py::init<const std::string&, const std::vector<StateT>&, const std::vector<std::chrono::nanoseconds>&>(),
+      "Constructor with name, initial points, and durations provided", "name"_a, "points"_a, "durations"_a
+  );
+
+  // specialized member functions that are trajectory type-dependent
+  if constexpr (std::is_same_v<StateT, CartesianState>) {
+    c.def("get_reference_frame", &CartesianTrajectory::get_reference_frame, "Get the reference frame");
+    c.def(
+        "set_reference_frame", &CartesianTrajectory::set_reference_frame,
+        "Set the reference frame that applies a transformation to all existing points to change the reference frame",
+        "pose"_a
+    );
+
+  } else if constexpr (std::is_same_v<StateT, JointState>) {
+    c.def("get_joint_names", &JointTrajectory::get_joint_names, "Get the joint names");
+    c.def("set_joint_names", &JointTrajectory::set_joint_names, "Set the joint names", "joint_names"_a);
+  }
+
+  // common functions
+  c.def(
+      "add_point", &TrajectoryT::add_point, "Add new point and corresponding duration to trajectory", "point"_a,
+      "duration"_a
+  );
+  c.def(
+      "add_points", &TrajectoryT::add_points, "Add new points and corresponding durations to trajectory", "points"_a,
+      "durations"_a
+  );
+  c.def(
+      "insert_point", &TrajectoryT::insert_point,
+      "Insert new point and corresponding duration to trajectory between two already existing points", "point"_a,
+      "index"_a, "duration"_a
+  );
+  c.def(
+      "set_point", &TrajectoryT::set_point, "Set the trajectory point at given index", "point"_a, "index"_a,
+      "duration"_a
+  );
+  c.def("set_points", &TrajectoryT::set_points, "Set the trajectory point at given index", "points"_a, "durations"_a);
+  c.def("get_points", &TrajectoryT::get_points, "Get list of trajectory points", py::return_value_policy::reference);
+  c.def("get_point", &TrajectoryT::get_point, "Get the trajectory point at given index", "index"_a);
+  c.def("__getitem__", &TrajectoryT::operator[], "Get the trajectory point at given index", "index"_a);
+}
+
+void bind_trajectory(py::module_& m) {
+  trajectory_points(m);
+  // ! not sure this is the best way to do this / perhaps we need a container class for python instead
+  // ! at the moment, we are technically creating a different base class per specialization
+  trajectory_base<CartesianTrajectoryPoint>(m);
+  trajectory_base<JointTrajectoryPoint>(m);
+
+  trajectory_derived<CartesianState>(m);
+  trajectory_derived<JointState>(m);
+}

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -100,7 +100,7 @@ void trajectory(py::module_& m) {
       "duration"_a
   );
   c.def("set_points", &TrajectoryT::set_points, "Set the trajectory point at given index", "points"_a, "durations"_a);
-  c.def("get_points", &TrajectoryT::get_points, "Get list of trajectory points", py::return_value_policy::reference);
+  c.def("get_points", &TrajectoryT::get_points, "Get list of trajectory points");
   c.def("get_point", &TrajectoryT::get_point, "Get the trajectory point at given index", "index"_a);
   c.def("__getitem__", &TrajectoryT::operator[], "Get the trajectory point at given index", "index"_a);
 }

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -1,74 +1,13 @@
+#include <string>
+#include <type_traits>
+
 #include "state_representation_bindings.hpp"
 
 #include <state_representation/trajectory/CartesianTrajectory.hpp>
 #include <state_representation/trajectory/JointTrajectory.hpp>
-#include <string>
-#include <type_traits>
-
-#include "parameter_container.hpp"
-#include "py_parameter_map.hpp"
-
-void trajectory_points(py::module_& m) {
-  // Cartesian trajectory point bindings
-  py::class_<CartesianTrajectoryPoint, std::shared_ptr<CartesianTrajectoryPoint>> ctp(m, "CartesianTrajectoryPoint");
-  ctp.def(py::init<>(), "Empty constructor");
-  ctp.def(
-      py::init<const CartesianState&, const std::chrono::nanoseconds&>(),
-      "Constructor from Cartesian state and duration"
-  );
-  ctp.def(
-      "to_cartesian_state", &CartesianTrajectoryPoint::to_cartesian_state,
-      "Convert the trajectory point to a Cartesian state", "reference_frame"_a
-  );
-
-  // Joint trajectory point bindings
-  py::class_<JointTrajectoryPoint, std::shared_ptr<JointTrajectoryPoint>> jtp(m, "JointTrajectoryPoint");
-  jtp.def(py::init<>(), "Empty constructor");
-  jtp.def(py::init<const JointState&, const std::chrono::nanoseconds&>(), "Constructor from joint state and duration");
-  jtp.def(
-      "to_joint_state", &JointTrajectoryPoint::to_joint_state, "Convert the trajectory point to a joint state",
-      "joint_names"_a
-  );
-}
-
-template<typename T>
-void trajectory_base(py::module_& m) {
-  std::string base_name;
-  if constexpr (std::is_same_v<T, CartesianTrajectoryPoint>) {
-    base_name = "CartesianTrajectoryBase";
-  } else if constexpr (std::is_same_v<T, JointTrajectoryPoint>) {
-    base_name = "JointTrajectoryBase";
-  } else {
-    static_assert(false, "Unsupported type for trajectory base");
-  }
-  py::class_<TrajectoryBase<T>, std::shared_ptr<TrajectoryBase<T>>, State> c(m, base_name.c_str());
-
-  c.def(
-      "get_duration", &TrajectoryBase<T>::get_duration, "Get the duration of the trajectory point at given index",
-      "index"_a
-  );
-  c.def("get_durations", &TrajectoryBase<T>::get_durations, "Get list of trajectory point durations");
-  c.def(
-      "get_time_from_start", &TrajectoryBase<T>::get_time_from_start,
-      "Get the time from start of the trajectory point at given index", "index"_a
-  );
-  c.def(
-      "get_times_from_start", &TrajectoryBase<T>::get_times_from_start, "Get list of trajectory point times from start"
-  );
-  c.def(
-      "get_trajectory_duration", &TrajectoryBase<T>::get_trajectory_duration, "Get the total duration of the trajectory"
-  );
-  c.def("get_size", &TrajectoryBase<T>::get_size, "Get number of points in trajectory");
-  c.def("delete_point", py::overload_cast<>(&TrajectoryBase<T>::delete_point), "Delete the last point from trajectory");
-  c.def(
-      "delete_point", py::overload_cast<unsigned int>(&TrajectoryBase<T>::delete_point),
-      "Delete the last point from trajectory", "index"_a
-  );
-  c.def("reset", &TrajectoryBase<T>::reset, "Reset trajectory");
-}
 
 template<typename StateT>
-void trajectory_derived(py::module_& m) {
+void trajectory(py::module_& m) {
   using namespace state_representation;
 
   std::string trajectory_type;
@@ -86,7 +25,7 @@ void trajectory_derived(py::module_& m) {
 
   // constructors
   py::class_<TrajectoryT, std::shared_ptr<TrajectoryT>> c(
-      m, trajectory_type.c_str(), py::base<TrajectoryBase<PointT>>()
+      m, trajectory_type.c_str(), py::base<State>()
   );
 
   if constexpr (std::is_same_v<StateT, CartesianState>) {
@@ -115,13 +54,34 @@ void trajectory_derived(py::module_& m) {
         "Set the reference frame that applies a transformation to all existing points to change the reference frame",
         "pose"_a
     );
-
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def("get_joint_names", &JointTrajectory::get_joint_names, "Get the joint names");
     c.def("set_joint_names", &JointTrajectory::set_joint_names, "Set the joint names", "joint_names"_a);
   }
 
   // common functions
+  c.def(
+      "get_duration", &TrajectoryT::get_duration, "Get the duration of the trajectory point at given index",
+      "index"_a
+  );
+  c.def("get_durations", &TrajectoryT::get_durations, "Get list of trajectory point durations");
+  c.def(
+      "get_time_from_start", &TrajectoryT::get_time_from_start,
+      "Get the time from start of the trajectory point at given index", "index"_a
+  );
+  c.def(
+      "get_times_from_start", &TrajectoryT::get_times_from_start, "Get list of trajectory point times from start"
+  );
+  c.def(
+      "get_trajectory_duration", &TrajectoryT::get_trajectory_duration, "Get the total duration of the trajectory"
+  );
+  c.def("get_size", &TrajectoryT::get_size, "Get number of points in trajectory");
+  c.def("delete_point", py::overload_cast<>(&TrajectoryT::delete_point), "Delete the last point from trajectory");
+  c.def(
+      "delete_point", py::overload_cast<unsigned int>(&TrajectoryT::delete_point),
+      "Delete the last point from trajectory", "index"_a
+  );
+  c.def("reset", &TrajectoryT::reset, "Reset trajectory");
   c.def(
       "add_point", &TrajectoryT::add_point, "Add new point and corresponding duration to trajectory", "point"_a,
       "duration"_a
@@ -146,12 +106,6 @@ void trajectory_derived(py::module_& m) {
 }
 
 void bind_trajectory(py::module_& m) {
-  trajectory_points(m);
-  // ! not sure this is the best way to do this / perhaps we need a container class for python instead
-  // ! at the moment, we are technically creating a different base class per specialization
-  trajectory_base<CartesianTrajectoryPoint>(m);
-  trajectory_base<JointTrajectoryPoint>(m);
-
-  trajectory_derived<CartesianState>(m);
-  trajectory_derived<JointState>(m);
+  trajectory<CartesianState>(m);
+  trajectory<JointState>(m);
 }

--- a/python/source/state_representation/state_representation_bindings.cpp
+++ b/python/source/state_representation/state_representation_bindings.cpp
@@ -21,4 +21,5 @@ PYBIND11_MODULE(state_representation, m) {
   bind_parameters(m);
   bind_geometry(m);
   bind_io_state(m);
+  bind_trajectory(m);
 }

--- a/python/test/state_representation/test_trajectory.py
+++ b/python/test/state_representation/test_trajectory.py
@@ -1,0 +1,285 @@
+import unittest
+import datetime
+from random import shuffle
+
+from state_representation import (
+    CartesianState,
+    JointState,
+    CartesianTrajectory,
+    JointTrajectory,
+    CartesianTrajectoryPoint,
+    JointTrajectoryPoint,
+    StateType,
+)
+
+from state_representation.exceptions import (
+    EmptyStateError,
+    IncompatibleStatesError,
+    IncompatibleReferenceFramesError,
+    IncompatibleSizeError,
+)
+
+
+class TestState(unittest.TestCase):
+    __num_random_tests = 10
+
+    __cartesian_state_attributes = [
+        "get_acceleration",
+        "get_angular_acceleration",
+        "get_angular_velocity",
+        "get_force",
+        "get_linear_acceleration",
+        "get_linear_velocity",
+        "get_orientation",
+        "get_orientation_coefficients",
+        "get_pose",
+        "get_position",
+        "get_torque",
+        "get_twist",
+        "get_wrench",
+    ]
+
+    __joint_state_attributes = [
+        "get_accelerations",
+        "get_positions",
+        "get_torques",
+        "get_velocities",
+    ]
+
+    def test_constructors(self):
+        # empty trajectory constructors
+        empty1 = CartesianTrajectory()
+        self.assertEqual(empty1.get_type(), StateType.CARTESIAN_TRAJECTORY)
+        self.assertEqual(empty1.get_name(), "")
+        self.assertTrue(empty1.is_empty())
+        self.assertEqual(empty1.get_reference_frame(), "")
+
+        empty2 = CartesianTrajectory("test")
+        self.assertEqual(empty2.get_type(), StateType.CARTESIAN_TRAJECTORY)
+        self.assertEqual(empty2.get_name(), "test")
+        self.assertTrue(empty2.is_empty())
+        self.assertEqual(empty2.get_reference_frame(), "world")
+
+        empty3 = CartesianTrajectory("test", "reference")
+        self.assertEqual(empty3.get_type(), StateType.CARTESIAN_TRAJECTORY)
+        self.assertEqual(empty3.get_name(), "test")
+        self.assertTrue(empty3.is_empty())
+        self.assertEqual(empty3.get_reference_frame(), "reference")
+
+        empty4 = JointTrajectory()
+        self.assertEqual(empty4.get_type(), StateType.JOINT_TRAJECTORY)
+        self.assertEqual(empty4.get_name(), "")
+        self.assertTrue(empty4.is_empty())
+
+        empty5 = JointTrajectory("test")
+        self.assertEqual(empty5.get_type(), StateType.JOINT_TRAJECTORY)
+        self.assertEqual(empty5.get_name(), "test")
+        self.assertTrue(empty5.is_empty())
+
+        with self.assertRaises(EmptyStateError):
+            CartesianTrajectory("test", CartesianState(), datetime.timedelta(seconds=0))
+
+        # trajectory constructors with data
+        dummy_cartesian_state = CartesianState.Random("world")
+        data1 = CartesianTrajectory("test", dummy_cartesian_state, datetime.timedelta(seconds=1))
+        self.assertEqual(data1.get_type(), StateType.CARTESIAN_TRAJECTORY)
+        self.assertEqual(data1.get_name(), "test")
+        self.assertFalse(data1.is_empty())
+        self.assertEqual(data1.get_reference_frame(), "world")
+
+        dummy_cartesian_state = CartesianState.Random("world")
+        data2 = CartesianTrajectory("test", [dummy_cartesian_state] * 5, [datetime.timedelta(seconds=1)] * 5)
+        self.assertEqual(data2.get_type(), StateType.CARTESIAN_TRAJECTORY)
+        self.assertEqual(data2.get_name(), "test")
+        self.assertFalse(data2.is_empty())
+        self.assertEqual(data2.get_reference_frame(), "world")
+        self.assertEqual(data2.get_size(), 5)
+
+        dummy_joint_state = JointState.Random("robot", 7)
+        data2 = JointTrajectory("test", dummy_joint_state, datetime.timedelta(seconds=1))
+        self.assertEqual(data2.get_type(), StateType.JOINT_TRAJECTORY)
+        self.assertEqual(data2.get_name(), "test")
+        self.assertFalse(data2.is_empty())
+
+        dummy_joint_state = JointState.Random("robot", 7)
+        data2 = JointTrajectory("test", [dummy_joint_state] * 5, [datetime.timedelta(seconds=1)] * 5)
+        self.assertEqual(data2.get_type(), StateType.JOINT_TRAJECTORY)
+        self.assertEqual(data2.get_name(), "test")
+        self.assertFalse(data2.is_empty())
+        self.assertEqual(data2.get_size(), 5)
+
+        with self.assertRaises(EmptyStateError):
+            empty6 = JointTrajectory("test", JointState(), datetime.timedelta(seconds=0))
+
+        # trajectory point constructors
+        dummy_cartesian_state = CartesianState.Random("world")
+        CartesianTrajectoryPoint(dummy_cartesian_state, datetime.timedelta(seconds=1))
+
+        dummy_joint_state = JointState.Random("robot", 7)
+        JointTrajectoryPoint(dummy_joint_state, datetime.timedelta(seconds=1))
+
+    def test_addremove_points(self):
+        for TrajectoryT in [CartesianTrajectory, JointTrajectory]:
+            trajectory = TrajectoryT("foo")
+
+            points = []
+            durations = []
+            for i in range(self.__num_random_tests):
+                points.append(
+                    CartesianState.Random("foo")
+                    if isinstance(trajectory, CartesianTrajectory)
+                    else JointState.Random("foo", 25)
+                )
+                durations.append(datetime.timedelta(seconds=(i + 1) * 10))
+
+            if isinstance(trajectory, JointTrajectory):
+                trajectory.set_joint_names(points[0].get_names())
+
+            for i, (point, duration) in enumerate(zip(points, durations)):
+                trajectory.add_point(point, duration)
+                self.assertEqual(trajectory.get_size(), i + 1)
+                self.assert_state_equality(trajectory[i][0], points[i])
+                self.assertEqual(trajectory[i][1], durations[i])
+
+            for i in range(self.__num_random_tests):
+                trajectory.delete_point(0)
+                self.assertEqual(trajectory.get_size(), self.__num_random_tests - i - 1) 
+
+            trajectory.add_points(points, durations)
+            self.assertEqual(trajectory.get_size(), self.__num_random_tests)
+            for i, (point, duration) in enumerate(zip(points, durations)):
+                self.assert_state_equality(trajectory[i][0], points[i])
+                self.assertEqual(trajectory[i][1], durations[i])
+
+            shuffled_points = points.copy()
+            shuffled_durations = durations.copy()
+            shuffle(shuffled_points)
+            shuffle(shuffled_durations)
+            for i, (point, duration) in enumerate(zip(shuffled_points, shuffled_durations)):
+                trajectory.set_point(point, duration, i)
+                self.assert_state_equality(trajectory[i][0], shuffled_points[i])
+                self.assertEqual(trajectory[i][1], shuffled_durations[i])
+
+            shuffle(shuffled_points)
+            shuffle(shuffled_durations)
+            trajectory.set_points(shuffled_points, shuffled_durations)
+            self.assertEqual(trajectory.get_size(), self.__num_random_tests)
+            for i, (point, duration) in enumerate(zip(shuffled_points, shuffled_durations)):
+                self.assert_state_equality(trajectory[i][0], shuffled_points[i])
+                self.assertEqual(trajectory[i][1], shuffled_durations[i])
+
+            insertion_point = (
+                CartesianState.Random("foo")
+                if isinstance(trajectory, CartesianTrajectory)
+                else JointState.Random("foo", 25)
+            )
+            insert_idx = self.__num_random_tests // 2
+            trajectory.insert_point(insertion_point, durations[0], insert_idx)
+            self.assertEqual(trajectory.get_size(), self.__num_random_tests + 1)
+            self.assert_state_equality(trajectory[insert_idx][0], insertion_point)
+            self.assertEqual(trajectory[insert_idx][1], durations[0])
+
+    def test_exceptions(self):
+        for TrajectoryT in [CartesianTrajectory, JointTrajectory]:
+            trajectory = TrajectoryT("foo")
+
+            points = []
+            durations = []
+            for i in range(self.__num_random_tests):
+                points.append(
+                    CartesianState.Random("foo")
+                    if isinstance(trajectory, CartesianTrajectory)
+                    else JointState.Random("foo", 25)
+                )
+                durations.append(datetime.timedelta(seconds=(i + 1) * 10))
+
+            if isinstance(trajectory, JointTrajectory):
+                trajectory.set_joint_names(points[0].get_names())
+
+            trajectory.add_points(points, durations)
+            with self.assertRaises(IndexError):
+                trajectory.get_point(self.__num_random_tests + 1)
+
+            trajectory.add_point(points[0], durations[0])
+            with self.assertRaises(IncompatibleSizeError):
+                trajectory.set_points(points, durations)
+
+            if isinstance(trajectory, CartesianTrajectory):
+                with self.assertRaises(IncompatibleReferenceFramesError):
+                    trajectory.add_point(CartesianState.Random("bar", "some_world"), durations[0])
+                with self.assertRaises(IncompatibleReferenceFramesError):
+                    trajectory.set_point(CartesianState.Random("bar", "some_world"), durations[0], 0)
+                with self.assertRaises(EmptyStateError):
+                    trajectory.add_point(CartesianState(), durations[0])
+            else:
+                with self.assertRaises(IncompatibleStatesError):
+                    trajectory.add_point(JointState.Random("foo", 24), durations[0])
+                with self.assertRaises(IncompatibleStatesError):
+                    trajectory.set_point(JointState.Random("foo", 24), durations[0], 0)
+                with self.assertRaises(EmptyStateError):
+                    trajectory.add_point(JointState(), durations[0])
+
+            with self.assertRaises(IndexError):
+                trajectory[self.__num_random_tests + 1]
+
+    def test_getters(self):
+        for TrajectoryT in [CartesianTrajectory, JointTrajectory]:
+            trajectory = TrajectoryT("foo")
+
+            points = []
+            durations = []
+            for i in range(self.__num_random_tests):
+                points.append(
+                    CartesianState.Random("foo")
+                    if isinstance(trajectory, CartesianTrajectory)
+                    else JointState.Random("foo", 25)
+                )
+                durations.append(datetime.timedelta(seconds=(i + 1) * 10))
+
+            if isinstance(trajectory, JointTrajectory):
+                trajectory.set_joint_names(points[0].get_names())
+
+            trajectory.add_points(points, durations)
+
+            for i, (point, duration) in enumerate(zip(points, durations)):
+                self.assert_state_equality(trajectory.get_point(i), point)
+                self.assertEqual(trajectory.get_duration(i), duration)
+                self.assert_state_equality(trajectory[i][0], point)
+                self.assertEqual(trajectory[i][1], duration)
+
+            times_from_start = trajectory.get_times_from_start()
+            time_from_start = 0
+            for i in range(len(times_from_start)):
+                time_from_start += durations[i].total_seconds()
+                self.assertAlmostEqual(time_from_start, times_from_start[i].total_seconds())
+                self.assertAlmostEqual(time_from_start, times_from_start[i].total_seconds())
+                self.assertAlmostEqual(trajectory.get_duration(i), durations[i])
+            self.assertAlmostEqual(trajectory.get_trajectory_duration().total_seconds(), time_from_start)
+
+            trajectory.reset()
+            self.assertTrue(trajectory.is_empty())
+            self.assertEqual(trajectory.get_size(), 0)
+            with self.assertRaises(EmptyStateError):
+                trajectory.get_durations()
+            if isinstance(trajectory, CartesianTrajectory):
+                self.assertEqual(trajectory.get_reference_frame(), "world")
+            else:
+                self.assertFalse(len(trajectory.get_joint_names()) == 0)
+
+    def assert_state_equality(self, state1, state2):
+        self.assertEqual(state1.get_type(), state2.get_type())
+        self.assertEqual(state1.get_name(), state2.get_name())
+        if isinstance(state1, CartesianState):
+            for attr in self.__cartesian_state_attributes:
+                for value1, value2 in zip(getattr(state1, attr)(), getattr(state2, attr)()):
+                    self.assertAlmostEqual(value1, value2)
+            self.assertEqual(state1.get_reference_frame(), state2.get_reference_frame())
+        else:
+            for attr in self.__joint_state_attributes:
+                for value1, value2 in zip(getattr(state1, attr)(), getattr(state2, attr)()):
+                    self.assertAlmostEqual(value1, value2)
+            self.assertEqual(state1.get_names(), state2.get_names())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/state_representation/test_trajectory.py
+++ b/python/test/state_representation/test_trajectory.py
@@ -7,9 +7,7 @@ from state_representation import (
     JointState,
     CartesianTrajectory,
     JointTrajectory,
-    CartesianTrajectoryPoint,
-    JointTrajectoryPoint,
-    StateType,
+    StateType
 )
 
 from state_representation.exceptions import (
@@ -110,13 +108,6 @@ class TestState(unittest.TestCase):
 
         with self.assertRaises(EmptyStateError):
             empty6 = JointTrajectory("test", JointState(), datetime.timedelta(seconds=0))
-
-        # trajectory point constructors
-        dummy_cartesian_state = CartesianState.Random("world")
-        CartesianTrajectoryPoint(dummy_cartesian_state, datetime.timedelta(seconds=1))
-
-        dummy_joint_state = JointState.Random("robot", 7)
-        JointTrajectoryPoint(dummy_joint_state, datetime.timedelta(seconds=1))
 
     def test_addremove_points(self):
         for TrajectoryT in [CartesianTrajectory, JointTrajectory]:


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #219 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding bindings for the new Trajectory classes as well as tests to validate a symmetric API for python/C++.

<del>There is one main aspect to be discussed (also mentioned in the code comments). Since our TrajectoryBase is templated, when binding the specialized classes (CartesianTrajectory and JointTrajectory) we face a problem where we redefine the base class name. </del>

<del>Python will complain.</del>

<del>For now, my approach was to practically create a base class per specialization, which results in `CartesianTrajectoryBase` and `JointTrajectoryBase`. That allows us to properly propagate inherited methods from `TrajectoryBase<>` and `State`, but is technically a workaround since it's not a 1-to-1 C++ equivalent.</del>

<del>We could potentially look at creating a container/interface of the base instead and define it for python in the bindings, but this would still not be 1-to-1.</del>

<del>In any case, `TrajectoryBase` does not have any public constructors, so one could argue that we don't quite need to expose it in Python.</del>

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 10 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->