### PR TITLE
feat: add copy constructors to trajectory classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Release Versions
 - feat: improve support for transformation matrices (#146)
 - fix: unstable python test (#221)
 - feat: move up to C++20 (#220)
-- feat: split trajectory classes and implement Cartesian/JointState specializations (#216, #217, #223)
+- feat: split trajectory classes and implement Cartesian/JointState specializations (#216, #217, #223, #226)
 - feat: add trajectory class bindings and python tests (#219)
 
 ## 9.1.0

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -45,12 +45,9 @@ void trajectory(py::module_& m) {
   if constexpr (std::is_same_v<StateT, CartesianState>) {
     c.def("get_reference_frame", &CartesianTrajectory::get_reference_frame, "Get the reference frame");
     c.def(
-        "set_reference_frame", py::overload_cast<const CartesianPose&>(&CartesianTrajectory::set_reference_frame),
+        "set_reference_frame", &CartesianTrajectory::set_reference_frame,
         "Set the reference frame by applying a transformation to all existing points to change the reference frame",
         "pose"_a);
-    c.def(
-        "set_reference_frame", py::overload_cast<const std::string&>(&CartesianTrajectory::set_reference_frame),
-        "Set the reference frame by simply changing the reference frame name", "reference_frame"_a);
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def("get_joint_names", &JointTrajectory::get_joint_names, "Get the joint names");
     c.def("set_joint_names", &JointTrajectory::set_joint_names, "Set the joint names", "joint_names"_a);

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -24,27 +24,22 @@ void trajectory(py::module_& m) {
       std::is_same_v<StateT, CartesianState>, CartesianTrajectoryPoint, JointTrajectoryPoint>::type;
 
   // constructors
-  py::class_<TrajectoryT, std::shared_ptr<TrajectoryT>> c(
-      m, trajectory_type.c_str(), py::base<State>()
-  );
+  py::class_<TrajectoryT, std::shared_ptr<TrajectoryT>> c(m, trajectory_type.c_str(), py::base<State>());
 
   if constexpr (std::is_same_v<StateT, CartesianState>) {
     c.def(py::init<>(), "Empty constructor");
     c.def(
         py::init<const std::string&, const std::string&>(), "Constructor with name and reference frame provided",
-        "name"_a, "reference_frame"_a = "world"
-    );
+        "name"_a, "reference_frame"_a = "world");
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def(py::init<const std::string&>(), "Constructor with optional name", "name"_a = "");
   }
   c.def(
       py::init<const std::string&, const StateT&, const std::chrono::nanoseconds&>(),
-      "Constructor with name, initial point, and duration provided", "name"_a, "point"_a, "duration"_a
-  );
+      "Constructor with name, initial point, and duration provided", "name"_a, "point"_a, "duration"_a);
   c.def(
       py::init<const std::string&, const std::vector<StateT>&, const std::vector<std::chrono::nanoseconds>&>(),
-      "Constructor with name, initial points, and durations provided", "name"_a, "points"_a, "durations"_a
-  );
+      "Constructor with name, initial points, and durations provided", "name"_a, "points"_a, "durations"_a);
 
   // specialized member functions that are trajectory type-dependent
   if constexpr (std::is_same_v<StateT, CartesianState>) {
@@ -52,13 +47,10 @@ void trajectory(py::module_& m) {
     c.def(
         "set_reference_frame", py::overload_cast<const CartesianPose&>(&CartesianTrajectory::set_reference_frame),
         "Set the reference frame by applying a transformation to all existing points to change the reference frame",
-        "pose"_a
-    );
+        "pose"_a);
     c.def(
         "set_reference_frame", py::overload_cast<const std::string&>(&CartesianTrajectory::set_reference_frame),
-        "Set the reference frame by simply changing the reference frame name",
-        "reference_frame"_a
-    );
+        "Set the reference frame by simply changing the reference frame name", "reference_frame"_a);
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def("get_joint_names", &JointTrajectory::get_joint_names, "Get the joint names");
     c.def("set_joint_names", &JointTrajectory::set_joint_names, "Set the joint names", "joint_names"_a);
@@ -66,44 +58,32 @@ void trajectory(py::module_& m) {
 
   // common functions
   c.def(
-      "get_duration", &TrajectoryT::get_duration, "Get the duration of the trajectory point at given index",
-      "index"_a
-  );
+      "get_duration", &TrajectoryT::get_duration, "Get the duration of the trajectory point at given index", "index"_a);
   c.def("get_durations", &TrajectoryT::get_durations, "Get list of trajectory point durations");
   c.def(
       "get_time_from_start", &TrajectoryT::get_time_from_start,
-      "Get the time from start of the trajectory point at given index", "index"_a
-  );
-  c.def(
-      "get_times_from_start", &TrajectoryT::get_times_from_start, "Get list of trajectory point times from start"
-  );
-  c.def(
-      "get_trajectory_duration", &TrajectoryT::get_trajectory_duration, "Get the total duration of the trajectory"
-  );
+      "Get the time from start of the trajectory point at given index", "index"_a);
+  c.def("get_times_from_start", &TrajectoryT::get_times_from_start, "Get list of trajectory point times from start");
+  c.def("get_trajectory_duration", &TrajectoryT::get_trajectory_duration, "Get the total duration of the trajectory");
   c.def("get_size", &TrajectoryT::get_size, "Get number of points in trajectory");
   c.def("delete_point", py::overload_cast<>(&TrajectoryT::delete_point), "Delete the last point from trajectory");
   c.def(
       "delete_point", py::overload_cast<unsigned int>(&TrajectoryT::delete_point),
-      "Delete the last point from trajectory", "index"_a
-  );
+      "Delete the last point from trajectory", "index"_a);
   c.def("reset", &TrajectoryT::reset, "Reset trajectory");
   c.def(
       "add_point", &TrajectoryT::add_point, "Add new point and corresponding duration to trajectory", "point"_a,
-      "duration"_a
-  );
+      "duration"_a);
   c.def(
       "add_points", &TrajectoryT::add_points, "Add new points and corresponding durations to trajectory", "points"_a,
-      "durations"_a
-  );
+      "durations"_a);
   c.def(
       "insert_point", &TrajectoryT::insert_point,
       "Insert new point and corresponding duration to trajectory between two already existing points", "point"_a,
-      "index"_a, "duration"_a
-  );
+      "index"_a, "duration"_a);
   c.def(
       "set_point", &TrajectoryT::set_point, "Set the trajectory point at given index", "point"_a, "index"_a,
-      "duration"_a
-  );
+      "duration"_a);
   c.def("set_points", &TrajectoryT::set_points, "Set the trajectory point at given index", "points"_a, "durations"_a);
   c.def("get_points", &TrajectoryT::get_points, "Get list of trajectory points");
   c.def("get_point", &TrajectoryT::get_point, "Get the trajectory point at given index", "index"_a);

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -31,8 +31,10 @@ void trajectory(py::module_& m) {
     c.def(
         py::init<const std::string&, const std::string&>(), "Constructor with name and reference frame provided",
         "name"_a, "reference_frame"_a = "world");
+    c.def(py::init<const CartesianTrajectory&>(), "Copy constructor of a CartesianTrajectory", "state"_a);
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def(py::init<const std::string&>(), "Constructor with optional name", "name"_a = "");
+    c.def(py::init<const JointTrajectory&>(), "Copy constructor of a JointTrajectory", "state"_a);
   }
   c.def(
       py::init<const std::string&, const StateT&, const std::chrono::nanoseconds&>(),
@@ -85,6 +87,9 @@ void trajectory(py::module_& m) {
   c.def("get_points", &TrajectoryT::get_points, "Get list of trajectory points");
   c.def("get_point", &TrajectoryT::get_point, "Get the trajectory point at given index", "index"_a);
   c.def("__getitem__", &TrajectoryT::operator[], "Get the trajectory point at given index", "index"_a);
+
+  c.def("__copy__", [](const TrajectoryT& state) { return TrajectoryT(state); });
+  c.def("__deepcopy__", [](const TrajectoryT& state, py::dict) { return TrajectoryT(state); }, "state"_a);
 }
 
 void bind_trajectory(py::module_& m) {

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -89,7 +89,7 @@ void trajectory(py::module_& m) {
   c.def("__getitem__", &TrajectoryT::operator[], "Get the trajectory point at given index", "index"_a);
 
   c.def("__copy__", [](const TrajectoryT& state) { return TrajectoryT(state); });
-  c.def("__deepcopy__", [](const TrajectoryT& state, py::dict) { return TrajectoryT(state); }, "state"_a);
+  c.def("__deepcopy__", [](const TrajectoryT& state, py::dict) { return TrajectoryT(state); }, "memo"_a);
 }
 
 void bind_trajectory(py::module_& m) {

--- a/python/source/state_representation/bind_trajectory.cpp
+++ b/python/source/state_representation/bind_trajectory.cpp
@@ -50,9 +50,14 @@ void trajectory(py::module_& m) {
   if constexpr (std::is_same_v<StateT, CartesianState>) {
     c.def("get_reference_frame", &CartesianTrajectory::get_reference_frame, "Get the reference frame");
     c.def(
-        "set_reference_frame", &CartesianTrajectory::set_reference_frame,
-        "Set the reference frame that applies a transformation to all existing points to change the reference frame",
+        "set_reference_frame", py::overload_cast<const CartesianPose&>(&CartesianTrajectory::set_reference_frame),
+        "Set the reference frame by applying a transformation to all existing points to change the reference frame",
         "pose"_a
+    );
+    c.def(
+        "set_reference_frame", py::overload_cast<const std::string&>(&CartesianTrajectory::set_reference_frame),
+        "Set the reference frame by simply changing the reference frame name",
+        "reference_frame"_a
     );
   } else if constexpr (std::is_same_v<StateT, JointState>) {
     c.def("get_joint_names", &JointTrajectory::get_joint_names, "Get the joint names");

--- a/python/test/state_representation/test_trajectory.py
+++ b/python/test/state_representation/test_trajectory.py
@@ -77,6 +77,9 @@ class TestState(unittest.TestCase):
         with self.assertRaises(EmptyStateError):
             CartesianTrajectory("test", CartesianState(), datetime.timedelta(seconds=0))
 
+        with self.assertRaises(EmptyStateError):
+            empty6 = JointTrajectory("test", JointState(), datetime.timedelta(seconds=0))
+
         # trajectory constructors with data
         dummy_cartesian_state = CartesianState.Random("world")
         data1 = CartesianTrajectory("test", dummy_cartesian_state, datetime.timedelta(seconds=1))
@@ -106,8 +109,25 @@ class TestState(unittest.TestCase):
         self.assertFalse(data2.is_empty())
         self.assertEqual(data2.get_size(), 5)
 
-        with self.assertRaises(EmptyStateError):
-            empty6 = JointTrajectory("test", JointState(), datetime.timedelta(seconds=0))
+        ct = CartesianTrajectory("test", 
+            [CartesianState.Random("foo"), CartesianState.Random("bar"), CartesianState.Random("baz")], 
+            [datetime.timedelta(seconds=1), datetime.timedelta(seconds=2), datetime.timedelta(seconds=3)])
+        ct_copy = CartesianTrajectory(ct)
+        self.assertEqual(ct.get_size(), ct_copy.get_size())
+        for i in range(ct.get_size()):
+            self.assert_state_equality(ct.get_point(i), ct_copy.get_point(i))
+            self.assertEqual(ct.get_duration(i), ct_copy.get_duration(i))
+        self.assertEqual(ct.get_reference_frame(), ct_copy.get_reference_frame())
+
+        jt = JointTrajectory("test", 
+            [JointState.Random("foo", 25), JointState.Random("bar", 25), JointState.Random("baz", 25)], 
+            [datetime.timedelta(seconds=1), datetime.timedelta(seconds=2), datetime.timedelta(seconds=3)])
+        ct_copy = JointTrajectory(jt)
+        self.assertEqual(jt.get_size(), ct_copy.get_size())
+        for i in range(jt.get_size()):
+            self.assert_state_equality(jt.get_point(i), ct_copy.get_point(i))
+            self.assertEqual(jt.get_duration(i), ct_copy.get_duration(i))
+        self.assertEqual(jt.get_joint_names(), ct_copy.get_joint_names())
 
     def test_addremove_points(self):
         for TrajectoryT in [CartesianTrajectory, JointTrajectory]:

--- a/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
@@ -97,12 +97,6 @@ public:
   void set_reference_frame(const CartesianPose& pose);
 
   /**
-   * @brief Set the reference frame by simply changing the reference frame name
-   * @param reference_frame the new reference frame
-   */
-  void set_reference_frame(const std::string& reference_frame);
-
-  /**
    * @brief Get list of trajectory points
    * @return queue of the Cartesian states of the trajectory
    */
@@ -178,6 +172,20 @@ public:
    */
   CartesianTrajectory& operator=(const CartesianTrajectory& trajectory);
 
+  /**
+   * @brief Swap the values of trajectories
+   * @param trajectory1 trajectory to be swapped with 2
+   * @param trajectory2 trajectory to be swapped with 1
+   */
+  friend inline void swap(CartesianTrajectory& trajectory1, CartesianTrajectory& trajectory2) {
+    swap(
+        static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory1),
+        static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory2));
+    auto tmp = trajectory1.reference_frame_;
+    trajectory1.reference_frame_ = trajectory2.reference_frame_;
+    trajectory2.reference_frame_ = tmp;
+  }
+
 private:
   /**
    * @brief Assert that all states of a vector carry the same reference frame
@@ -196,14 +204,4 @@ private:
 
   std::string reference_frame_;///< name of the reference frame
 };
-
-inline void swap(CartesianTrajectory& trajectory1, CartesianTrajectory& trajectory2) {
-  swap(
-      static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory1),
-      static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory2));
-  auto tmp = trajectory1.get_reference_frame();
-  trajectory1.set_reference_frame(trajectory2.get_reference_frame());
-  trajectory2.set_reference_frame(tmp);
-}
-
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
@@ -62,8 +62,7 @@ public:
    * @throw EmptyStateException if point is empty
    */
   explicit CartesianTrajectory(
-      const std::string& name, const CartesianState& point, const std::chrono::nanoseconds& duration
-  );
+      const std::string& name, const CartesianState& point, const std::chrono::nanoseconds& duration);
 
   /**
    * @brief Constructor with name, intial points, and durations provided
@@ -76,8 +75,7 @@ public:
    */
   explicit CartesianTrajectory(
       const std::string& name, const std::vector<CartesianState>& points,
-      const std::vector<std::chrono::nanoseconds>& durations
-  );
+      const std::vector<std::chrono::nanoseconds>& durations);
 
   /**
    * @brief Copy constructor of a CartesianTrajectory

--- a/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
@@ -80,17 +80,29 @@ public:
   );
 
   /**
+   * @brief Copy constructor of a CartesianTrajectory
+   * @param state the Cartesian trajectory to copy from
+   */
+  CartesianTrajectory(const CartesianTrajectory& state);
+
+  /**
    * @brief Get the reference frame
    * @return the reference frame associated with the trajectory
    */
   const std::string& get_reference_frame() const;
 
   /**
-   * @brief Set the reference frame that applies a transformation to all existing points to change the reference frame
+   * @brief Set the reference frame by applying a transformation to all existing points to change the reference frame
    * @param pose the new pose that needs to be applied to existing points to change the reference frame
    * @throws EmptyStateException if pose is empty
    */
   void set_reference_frame(const CartesianPose& pose);
+
+  /**
+   * @brief Set the reference frame by simply changing the reference frame name
+   * @param reference_frame the new reference frame
+   */
+  void set_reference_frame(const std::string& reference_frame);
 
   /**
    * @brief Get list of trajectory points
@@ -161,6 +173,13 @@ public:
    */
   std::pair<CartesianState, const std::chrono::nanoseconds> operator[](unsigned int idx) const;
 
+  /**
+   * @brief Copy assignment operator that has to be defined to the custom assignment operator
+   * @param trajectory the trajectory with value to assign
+   * @return reference to the current trajectory with new values
+   */
+  CartesianTrajectory& operator=(const CartesianTrajectory& trajectory);
+
 private:
   /**
    * @brief Assert that all states of a vector carry the same reference frame
@@ -179,4 +198,14 @@ private:
 
   std::string reference_frame_;///< name of the reference frame
 };
+
+inline void swap(CartesianTrajectory& trajectory1, CartesianTrajectory& trajectory2) {
+  swap(
+      static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory1),
+      static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory2));
+  auto tmp = trajectory1.get_reference_frame();
+  trajectory1.set_reference_frame(trajectory2.get_reference_frame());
+  trajectory2.set_reference_frame(tmp);
+}
+
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/CartesianTrajectory.hpp
@@ -181,9 +181,7 @@ public:
     swap(
         static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory1),
         static_cast<TrajectoryBase<CartesianTrajectoryPoint>&>(trajectory2));
-    auto tmp = trajectory1.reference_frame_;
-    trajectory1.reference_frame_ = trajectory2.reference_frame_;
-    trajectory2.reference_frame_ = tmp;
+    std::swap(trajectory1.reference_frame_, trajectory2.reference_frame_);
   }
 
 private:

--- a/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
@@ -158,6 +158,20 @@ public:
    */
   JointTrajectory& operator=(const JointTrajectory& trajectory);
 
+  /**
+   * @brief Swap the values of trajectories
+   * @param trajectory1 trajectory to be swapped with 2
+   * @param trajectory2 trajectory to be swapped with 1
+   */
+  friend inline void swap(JointTrajectory& trajectory1, JointTrajectory& trajectory2) {
+    swap(
+        static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory1),
+        static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory2));
+    auto tmp = trajectory1.get_joint_names();
+    trajectory1.joint_names_ = trajectory2.joint_names_;
+    trajectory2.joint_names_ = tmp;
+  }
+
 private:
   /**
    * @brief Assert that all states of a vector carry the same joint names
@@ -177,14 +191,4 @@ private:
 
   std::vector<std::string> joint_names_;///< names of the joints
 };
-
-inline void swap(JointTrajectory& trajectory1, JointTrajectory& trajectory2) {
-  swap(
-      static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory1),
-      static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory2));
-  auto tmp = trajectory1.get_joint_names();
-  trajectory1.set_joint_names(trajectory2.get_joint_names());
-  trajectory2.set_joint_names(tmp);
-}
-
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
@@ -167,9 +167,7 @@ public:
     swap(
         static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory1),
         static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory2));
-    auto tmp = trajectory1.get_joint_names();
-    trajectory1.joint_names_ = trajectory2.joint_names_;
-    trajectory2.joint_names_ = tmp;
+    std::swap(trajectory1.joint_names_, trajectory2.joint_names_);
   }
 
 private:

--- a/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
@@ -62,8 +62,7 @@ public:
    */
   explicit JointTrajectory(
       const std::string& name, const std::vector<JointState>& points,
-      const std::vector<std::chrono::nanoseconds>& durations
-  );
+      const std::vector<std::chrono::nanoseconds>& durations);
 
   /**
    * @brief Copy constructor of a JointTrajectory
@@ -173,8 +172,8 @@ private:
    * @param reference_frame the joint names to check against
    * @throw IncompatibleStatesException if a state has a different joint names
    */
-  void assert_compatible_joint_names(const std::vector<JointState>& states, const std::vector<std::string>& joint_names)
-      const;
+  void assert_compatible_joint_names(
+      const std::vector<JointState>& states, const std::vector<std::string>& joint_names) const;
 
   std::vector<std::string> joint_names_;///< names of the joints
 };

--- a/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
+++ b/source/state_representation/include/state_representation/trajectory/JointTrajectory.hpp
@@ -66,6 +66,12 @@ public:
   );
 
   /**
+   * @brief Copy constructor of a JointTrajectory
+   * @param state the joint trajectory to copy from
+   */
+  JointTrajectory(const JointTrajectory& state);
+
+  /**
    * @brief Get the joint names
    * @return vector of joint names associated with the trajectory
    */
@@ -146,6 +152,13 @@ public:
    */
   std::pair<JointState, const std::chrono::nanoseconds> operator[](unsigned int idx) const;
 
+  /**
+   * @brief Copy assignment operator that has to be defined to the custom assignment operator
+   * @param trajectory the trajectory with value to assign
+   * @return reference to the current trajectory with new values
+   */
+  JointTrajectory& operator=(const JointTrajectory& trajectory);
+
 private:
   /**
    * @brief Assert that all states of a vector carry the same joint names
@@ -165,4 +178,14 @@ private:
 
   std::vector<std::string> joint_names_;///< names of the joints
 };
+
+inline void swap(JointTrajectory& trajectory1, JointTrajectory& trajectory2) {
+  swap(
+      static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory1),
+      static_cast<TrajectoryBase<JointTrajectoryPoint>&>(trajectory2));
+  auto tmp = trajectory1.get_joint_names();
+  trajectory1.set_joint_names(trajectory2.get_joint_names());
+  trajectory2.set_joint_names(tmp);
+}
+
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/trajectory/TrajectoryBase.hpp
+++ b/source/state_representation/include/state_representation/trajectory/TrajectoryBase.hpp
@@ -224,6 +224,16 @@ protected:
     requires std::derived_from<StateT, typename state_representation::State>
   void assert_not_contains_empty_state(const std::vector<StateT>& states) const;
 
+  /**
+   * @brief Swap the values of trajectories
+   * @param trajectory1 trajectory to be swapped with 2
+   * @param trajectory2 trajectory to be swapped with 1
+   */
+  friend void swap(TrajectoryBase<TrajectoryT>& trajectory1, TrajectoryBase<TrajectoryT>& trajectory2) {
+    swap(static_cast<State&>(trajectory1), static_cast<State&>(trajectory2));
+    std::swap(trajectory1.points_, trajectory2.points_);
+  }
+
 private:
   std::deque<TrajectoryT> points_;
 };

--- a/source/state_representation/include/state_representation/trajectory/TrajectoryBase.hpp
+++ b/source/state_representation/include/state_representation/trajectory/TrajectoryBase.hpp
@@ -403,8 +403,7 @@ inline void TrajectoryBase<TrajectoryT>::assert_points_size(const std::vector<T>
 template<typename TrajectoryT>
 template<typename T>
 inline void TrajectoryBase<TrajectoryT>::assert_points_durations_sizes_equal(
-    const std::vector<T>& points, const std::vector<std::chrono::nanoseconds>& durations
-) const {
+    const std::vector<T>& points, const std::vector<std::chrono::nanoseconds>& durations) const {
   if (points.size() != durations.size()) {
     throw exceptions::IncompatibleSizeException(
         "The size of the provided points and durations vectors are not equal (" + std::to_string(points.size())

--- a/source/state_representation/src/trajectory/CartesianTrajectory.cpp
+++ b/source/state_representation/src/trajectory/CartesianTrajectory.cpp
@@ -15,16 +15,14 @@ CartesianTrajectory::CartesianTrajectory(const std::string& name, const std::str
 }
 
 CartesianTrajectory::CartesianTrajectory(
-    const std::string& name, const CartesianState& point, const std::chrono::nanoseconds& duration
-)
+    const std::string& name, const CartesianState& point, const std::chrono::nanoseconds& duration)
     : CartesianTrajectory(name, point.get_reference_frame()) {
   this->add_point(point, duration);
 }
 
 CartesianTrajectory::CartesianTrajectory(
     const std::string& name, const std::vector<CartesianState>& points,
-    const std::vector<std::chrono::nanoseconds>& durations
-)
+    const std::vector<std::chrono::nanoseconds>& durations)
     : CartesianTrajectory(name) {
   this->assert_points_not_empty(points);
   this->reference_frame_ = points[0].get_reference_frame();
@@ -71,8 +69,7 @@ void CartesianTrajectory::add_point(const CartesianState& point, const std::chro
 }
 
 void CartesianTrajectory::add_points(
-    const std::vector<CartesianState>& points, const std::vector<std::chrono::nanoseconds>& durations
-) {
+    const std::vector<CartesianState>& points, const std::vector<std::chrono::nanoseconds>& durations) {
   this->assert_points_not_empty(points);
   this->assert_points_durations_sizes_equal(points, durations);
   this->assert_not_contains_empty_state(points);
@@ -83,24 +80,21 @@ void CartesianTrajectory::add_points(
 }
 
 void CartesianTrajectory::insert_point(
-    const CartesianState& point, const std::chrono::nanoseconds& duration, unsigned int index
-) {
+    const CartesianState& point, const std::chrono::nanoseconds& duration, unsigned int index) {
   this->assert_not_contains_empty_state<CartesianState>({point});
   this->assert_same_reference_frame({point}, this->reference_frame_);
   this->TrajectoryBase<CartesianTrajectoryPoint>::insert_point(CartesianTrajectoryPoint(point, duration), index);
 }
 
 void CartesianTrajectory::set_point(
-    const CartesianState& point, const std::chrono::nanoseconds& duration, unsigned int index
-) {
+    const CartesianState& point, const std::chrono::nanoseconds& duration, unsigned int index) {
   this->assert_not_contains_empty_state<CartesianState>({point});
   this->assert_same_reference_frame({point}, this->reference_frame_);
   this->TrajectoryBase<CartesianTrajectoryPoint>::set_point(CartesianTrajectoryPoint(point, duration), index);
 }
 
 void CartesianTrajectory::set_points(
-    const std::vector<CartesianState>& points, const std::vector<std::chrono::nanoseconds>& durations
-) {
+    const std::vector<CartesianState>& points, const std::vector<std::chrono::nanoseconds>& durations) {
   this->assert_points_not_empty(points);
   this->assert_points_size(points);
   this->assert_points_durations_sizes_equal(points, durations);
@@ -130,12 +124,10 @@ void CartesianTrajectory::assert_same_reference_frame(const std::vector<Cartesia
 }
 
 void CartesianTrajectory::assert_same_reference_frame(
-    const std::vector<CartesianState>& states, const std::string& reference_frame
-) const {
+    const std::vector<CartesianState>& states, const std::string& reference_frame) const {
   if (!std::ranges::all_of(states, [&](const auto& state) { return state.get_reference_frame() == reference_frame; })) {
     throw exceptions::IncompatibleReferenceFramesException(
-        "Incompatible reference frame " + states.front().get_reference_frame() + " and " + reference_frame
-    );
+        "Incompatible reference frame " + states.front().get_reference_frame() + " and " + reference_frame);
   }
 }
 }// namespace state_representation

--- a/source/state_representation/src/trajectory/CartesianTrajectory.cpp
+++ b/source/state_representation/src/trajectory/CartesianTrajectory.cpp
@@ -31,6 +31,13 @@ CartesianTrajectory::CartesianTrajectory(
   this->add_points(points, durations);
 }
 
+CartesianTrajectory::CartesianTrajectory(const CartesianTrajectory& state)
+    : CartesianTrajectory(state.get_name(), state.get_reference_frame()) {
+  if (state) {
+    this->add_points(state.get_points(), state.get_durations());
+  }
+}
+
 const std::string& CartesianTrajectory::get_reference_frame() const {
   return this->reference_frame_;
 }
@@ -40,6 +47,10 @@ void CartesianTrajectory::set_reference_frame(const CartesianPose& pose) {
   this->reference_frame_ = pose.get_reference_frame();
   std::transform(points.begin(), points.end(), points.begin(), [&](const auto& point) { return point * pose; });
   this->set_points(points, this->get_durations());
+}
+
+void CartesianTrajectory::set_reference_frame(const std::string& reference_frame) {
+  this->reference_frame_ = reference_frame;
 }
 
 const std::vector<CartesianState> CartesianTrajectory::get_points() const {
@@ -101,6 +112,15 @@ void CartesianTrajectory::set_points(
 std::pair<CartesianState, const std::chrono::nanoseconds> CartesianTrajectory::operator[](unsigned int idx) const {
   auto point = this->TrajectoryBase<CartesianTrajectoryPoint>::operator[](idx);
   return std::make_pair(point.to_cartesian_state(this->reference_frame_), point.duration);
+}
+
+CartesianTrajectory& CartesianTrajectory::operator=(const CartesianTrajectory& trajectory) {
+  if (this != &trajectory) {
+    this->reset();
+    CartesianTrajectory tmp(trajectory);
+    swap(*this, tmp);
+  }
+  return *this;
 }
 
 void CartesianTrajectory::assert_same_reference_frame(const std::vector<CartesianState>& states) const {

--- a/source/state_representation/src/trajectory/CartesianTrajectory.cpp
+++ b/source/state_representation/src/trajectory/CartesianTrajectory.cpp
@@ -106,7 +106,6 @@ std::pair<CartesianState, const std::chrono::nanoseconds> CartesianTrajectory::o
 
 CartesianTrajectory& CartesianTrajectory::operator=(const CartesianTrajectory& trajectory) {
   if (this != &trajectory) {
-    this->reset();
     CartesianTrajectory tmp(trajectory);
     swap(*this, tmp);
   }

--- a/source/state_representation/src/trajectory/CartesianTrajectory.cpp
+++ b/source/state_representation/src/trajectory/CartesianTrajectory.cpp
@@ -30,7 +30,7 @@ CartesianTrajectory::CartesianTrajectory(
 }
 
 CartesianTrajectory::CartesianTrajectory(const CartesianTrajectory& state)
-    : CartesianTrajectory(state.get_name(), state.get_reference_frame()) {
+    : CartesianTrajectory(state.get_name(), state.reference_frame_) {
   if (state) {
     this->add_points(state.get_points(), state.get_durations());
   }
@@ -45,10 +45,6 @@ void CartesianTrajectory::set_reference_frame(const CartesianPose& pose) {
   this->reference_frame_ = pose.get_reference_frame();
   std::transform(points.begin(), points.end(), points.begin(), [&](const auto& point) { return point * pose; });
   this->set_points(points, this->get_durations());
-}
-
-void CartesianTrajectory::set_reference_frame(const std::string& reference_frame) {
-  this->reference_frame_ = reference_frame;
 }
 
 const std::vector<CartesianState> CartesianTrajectory::get_points() const {

--- a/source/state_representation/src/trajectory/JointTrajectory.cpp
+++ b/source/state_representation/src/trajectory/JointTrajectory.cpp
@@ -30,6 +30,13 @@ JointTrajectory::JointTrajectory(
   this->add_points(points, durations);
 }
 
+JointTrajectory::JointTrajectory(const JointTrajectory& state) : JointTrajectory(state.get_name()) {
+  this->joint_names_ = state.get_joint_names();
+  if (state) {
+    this->add_points(state.get_points(), state.get_durations());
+  }
+}
+
 const std::vector<std::string>& JointTrajectory::get_joint_names() const {
   return this->joint_names_;
 }
@@ -95,6 +102,15 @@ void JointTrajectory::set_points(
 std::pair<JointState, const std::chrono::nanoseconds> JointTrajectory::operator[](unsigned int idx) const {
   auto point = this->TrajectoryBase<JointTrajectoryPoint>::operator[](idx);
   return std::make_pair(point.to_joint_state(this->joint_names_), point.duration);
+}
+
+JointTrajectory& JointTrajectory::operator=(const JointTrajectory& trajectory) {
+  if (this != &trajectory) {
+    this->reset();
+    JointTrajectory tmp(trajectory);
+    swap(*this, tmp);
+  }
+  return *this;
 }
 
 void JointTrajectory::assert_compatible_joint_names(const std::vector<JointState>& states) const {

--- a/source/state_representation/src/trajectory/JointTrajectory.cpp
+++ b/source/state_representation/src/trajectory/JointTrajectory.cpp
@@ -101,7 +101,6 @@ std::pair<JointState, const std::chrono::nanoseconds> JointTrajectory::operator[
 
 JointTrajectory& JointTrajectory::operator=(const JointTrajectory& trajectory) {
   if (this != &trajectory) {
-    this->reset();
     JointTrajectory tmp(trajectory);
     swap(*this, tmp);
   }

--- a/source/state_representation/src/trajectory/JointTrajectory.cpp
+++ b/source/state_representation/src/trajectory/JointTrajectory.cpp
@@ -12,8 +12,7 @@ JointTrajectory::JointTrajectory(const std::string& name) : TrajectoryBase<Joint
 }
 
 JointTrajectory::JointTrajectory(
-    const std::string& name, const JointState& point, const std::chrono::nanoseconds& duration
-)
+    const std::string& name, const JointState& point, const std::chrono::nanoseconds& duration)
     : JointTrajectory(name) {
   this->assert_points_not_empty<JointState>({point});
   this->joint_names_ = point.get_names();
@@ -22,8 +21,7 @@ JointTrajectory::JointTrajectory(
 
 JointTrajectory::JointTrajectory(
     const std::string& name, const std::vector<JointState>& points,
-    const std::vector<std::chrono::nanoseconds>& durations
-)
+    const std::vector<std::chrono::nanoseconds>& durations)
     : JointTrajectory(name) {
   this->assert_points_not_empty(points);
   this->joint_names_ = points[0].get_names();
@@ -63,8 +61,7 @@ void JointTrajectory::add_point(const JointState& point, const std::chrono::nano
 }
 
 void JointTrajectory::add_points(
-    const std::vector<JointState>& points, const std::vector<std::chrono::nanoseconds>& durations
-) {
+    const std::vector<JointState>& points, const std::vector<std::chrono::nanoseconds>& durations) {
   this->assert_points_not_empty(points);
   this->assert_points_durations_sizes_equal(points, durations);
   this->assert_not_contains_empty_state(points);
@@ -75,8 +72,7 @@ void JointTrajectory::add_points(
 }
 
 void JointTrajectory::insert_point(
-    const JointState& point, const std::chrono::nanoseconds& duration, unsigned int index
-) {
+    const JointState& point, const std::chrono::nanoseconds& duration, unsigned int index) {
   this->assert_not_contains_empty_state<JointState>({point});
   this->assert_compatible_joint_names({point}, this->joint_names_);
   this->TrajectoryBase<JointTrajectoryPoint>::insert_point(JointTrajectoryPoint(point, duration), index);
@@ -89,8 +85,7 @@ void JointTrajectory::set_point(const JointState& point, const std::chrono::nano
 }
 
 void JointTrajectory::set_points(
-    const std::vector<JointState>& points, const std::vector<std::chrono::nanoseconds>& durations
-) {
+    const std::vector<JointState>& points, const std::vector<std::chrono::nanoseconds>& durations) {
   this->assert_points_not_empty(points);
   this->assert_points_size(points);
   this->assert_points_durations_sizes_equal(points, durations);
@@ -120,8 +115,7 @@ void JointTrajectory::assert_compatible_joint_names(const std::vector<JointState
 }
 
 void JointTrajectory::assert_compatible_joint_names(
-    const std::vector<JointState>& states, const std::vector<std::string>& joint_names
-) const {
+    const std::vector<JointState>& states, const std::vector<std::string>& joint_names) const {
   if (!std::ranges::all_of(states, [&](const auto& state) { return state.get_names() == joint_names; })) {
     throw exceptions::IncompatibleStatesException("Incompatible joint names");
   }

--- a/source/state_representation/test/tests/test_trajectory.cpp
+++ b/source/state_representation/test/tests/test_trajectory.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <gtest/gtest.h>
+#include <state_representation/space/cartesian/CartesianState.hpp>
 #include <stdexcept>
 #include <type_traits>
 
@@ -129,6 +130,30 @@ TEST(TrajectoryTest, ConstructTrajectory) {
           "foo", {CartesianState::Random("foo"), CartesianState::Random("foo")}, {std::chrono::nanoseconds(100)}),
       exceptions::IncompatibleSizeException);
 
+  CartesianTrajectory ct(
+      "foo", {CartesianState::Random("foo"), CartesianState::Random("bar"), CartesianState::Random("baz")},
+      {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200), std::chrono::nanoseconds(300)});
+  EXPECT_NO_THROW(CartesianTrajectory ct_copy(ct));
+  {
+    CartesianTrajectory ct_copy(ct);
+    EXPECT_EQ(ct.get_size(), ct_copy.get_size());
+    for (unsigned int i = 0; i < ct.get_size(); ++i) {
+      EXPECT_EQ(ct.get_point(i).data(), ct_copy.get_point(i).data());
+      EXPECT_EQ(ct.get_duration(i), ct_copy.get_duration(i));
+    }
+    EXPECT_STREQ(ct.get_reference_frame().c_str(), ct_copy.get_reference_frame().c_str());
+  }
+  {
+    CartesianTrajectory ct_copy;
+    EXPECT_NO_THROW(ct_copy = ct);
+    EXPECT_EQ(ct.get_size(), ct_copy.get_size());
+    for (unsigned int i = 0; i < ct.get_size(); ++i) {
+      EXPECT_EQ(ct.get_point(i).data(), ct_copy.get_point(i).data());
+      EXPECT_EQ(ct.get_duration(i), ct_copy.get_duration(i));
+    }
+    EXPECT_STREQ(ct.get_reference_frame().c_str(), ct_copy.get_reference_frame().c_str());
+  }
+
   // Joint trajectory
   EXPECT_NO_THROW(JointTrajectory trajectory("foo"));
   EXPECT_NO_THROW(JointTrajectory trajectory("foo", JointState::Random("foo", 25), std::chrono::nanoseconds(100)));
@@ -145,6 +170,30 @@ TEST(TrajectoryTest, ConstructTrajectory) {
       JointTrajectory trajectory(
           "foo", {JointState::Random("foo", 25), JointState::Random("foo", 25)}, {std::chrono::nanoseconds(100)}),
       exceptions::IncompatibleSizeException);
+
+  JointTrajectory jt(
+      "foo", {JointState::Random("foo", 25), JointState::Random("bar", 25), JointState::Random("baz", 25)},
+      {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200), std::chrono::nanoseconds(300)});
+  EXPECT_NO_THROW(JointTrajectory ct_copy(jt));
+  {
+    JointTrajectory ct_copy(jt);
+    EXPECT_EQ(jt.get_size(), ct_copy.get_size());
+    for (unsigned int i = 0; i < jt.get_size(); ++i) {
+      EXPECT_EQ(jt.get_point(i).data(), ct_copy.get_point(i).data());
+      EXPECT_EQ(jt.get_duration(i), ct_copy.get_duration(i));
+    }
+    EXPECT_EQ(jt.get_joint_names(), ct_copy.get_joint_names());
+  }
+  {
+    JointTrajectory ct_copy;
+    EXPECT_NO_THROW(ct_copy = jt);
+    EXPECT_EQ(jt.get_size(), ct_copy.get_size());
+    for (unsigned int i = 0; i < jt.get_size(); ++i) {
+      EXPECT_EQ(jt.get_point(i).data(), ct_copy.get_point(i).data());
+      EXPECT_EQ(jt.get_duration(i), ct_copy.get_duration(i));
+    }
+    EXPECT_EQ(jt.get_joint_names(), ct_copy.get_joint_names());
+  }
 }
 
 TYPED_TEST_P(TrajectoryTest, AddRemovePoints) {

--- a/source/state_representation/test/tests/test_trajectory.cpp
+++ b/source/state_representation/test/tests/test_trajectory.cpp
@@ -114,26 +114,20 @@ TEST(TrajectoryTest, ConstructTrajectory) {
   EXPECT_NO_THROW(CartesianTrajectory trajectory("foo"));
   EXPECT_NO_THROW(CartesianTrajectory trajectory("foo", CartesianState::Random("foo"), std::chrono::nanoseconds(100)));
   EXPECT_NO_THROW(
-      CartesianTrajectory trajectory("foo", {CartesianState::Random("foo")}, {std::chrono::nanoseconds(100)})
-  );
+      CartesianTrajectory trajectory("foo", {CartesianState::Random("foo")}, {std::chrono::nanoseconds(100)}));
 
   EXPECT_THROW(
       CartesianTrajectory trajectory("foo", CartesianState(), std::chrono::nanoseconds(100)),
-      exceptions::EmptyStateException
-  );
+      exceptions::EmptyStateException);
   EXPECT_THROW(
       CartesianTrajectory trajectory(
           "foo", {CartesianState::Random("foo", "some_world"), CartesianState::Random("foo")},
-          {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200)}
-      ),
-      exceptions::IncompatibleReferenceFramesException
-  );
+          {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200)}),
+      exceptions::IncompatibleReferenceFramesException);
   EXPECT_THROW(
       CartesianTrajectory trajectory(
-          "foo", {CartesianState::Random("foo"), CartesianState::Random("foo")}, {std::chrono::nanoseconds(100)}
-      ),
-      exceptions::IncompatibleSizeException
-  );
+          "foo", {CartesianState::Random("foo"), CartesianState::Random("foo")}, {std::chrono::nanoseconds(100)}),
+      exceptions::IncompatibleSizeException);
 
   // Joint trajectory
   EXPECT_NO_THROW(JointTrajectory trajectory("foo"));
@@ -141,21 +135,16 @@ TEST(TrajectoryTest, ConstructTrajectory) {
   EXPECT_NO_THROW(JointTrajectory trajectory("foo", {JointState::Random("foo", 25)}, {std::chrono::nanoseconds(100)}));
 
   EXPECT_THROW(
-      JointTrajectory trajectory("foo", JointState(), std::chrono::nanoseconds(100)), exceptions::EmptyStateException
-  );
+      JointTrajectory trajectory("foo", JointState(), std::chrono::nanoseconds(100)), exceptions::EmptyStateException);
   EXPECT_THROW(
       JointTrajectory trajectory(
           "foo", {JointState::Random("foo", 25), JointState::Random("foo", 24)},
-          {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200)}
-      ),
-      exceptions::IncompatibleStatesException
-  );
+          {std::chrono::nanoseconds(100), std::chrono::nanoseconds(200)}),
+      exceptions::IncompatibleStatesException);
   EXPECT_THROW(
       JointTrajectory trajectory(
-          "foo", {JointState::Random("foo", 25), JointState::Random("foo", 25)}, {std::chrono::nanoseconds(100)}
-      ),
-      exceptions::IncompatibleSizeException
-  );
+          "foo", {JointState::Random("foo", 25), JointState::Random("foo", 25)}, {std::chrono::nanoseconds(100)}),
+      exceptions::IncompatibleSizeException);
 }
 
 TYPED_TEST_P(TrajectoryTest, AddRemovePoints) {
@@ -220,16 +209,14 @@ TYPED_TEST_P(TrajectoryTest, AddRemovePoints) {
   // additons and insertions of multiple points
   std::vector<PointType> points = {point0, point1, point2};
   std::vector<std::chrono::nanoseconds> durations = {
-      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)
-  };
+      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)};
   EXPECT_NO_THROW(this->add_points(points, durations));
   for (unsigned int i = 0; i < this->trajectory->get_size(); ++i) {
     this->expect_equal(points[i], i, durations[i]);
   }
   std::vector<PointType> shuffled_points = {point2, point0, point1};
   std::vector<std::chrono::nanoseconds> shuffled_durations = {
-      std::chrono::nanoseconds(30), std::chrono::nanoseconds(10), std::chrono::nanoseconds(20)
-  };
+      std::chrono::nanoseconds(30), std::chrono::nanoseconds(10), std::chrono::nanoseconds(20)};
   EXPECT_NO_THROW(this->set_points(shuffled_points, shuffled_durations));
   for (unsigned int i = 0; i < this->trajectory->get_size(); ++i) {
     this->expect_equal(shuffled_points[i], i, shuffled_durations[i]);
@@ -274,8 +261,7 @@ TYPED_TEST_P(TrajectoryTest, Exceptions) {
 
   std::vector<PointType> points = {point0, point1, point2};
   std::vector<std::chrono::nanoseconds> durations = {
-      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)
-  };
+      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)};
   EXPECT_NO_THROW(this->add_points(points, durations));
 
   EXPECT_THROW(this->delete_point_index(10), std::out_of_range);
@@ -338,8 +324,7 @@ TYPED_TEST_P(TrajectoryTest, Getters) {
 
   std::vector<PointType> points = {point0, point1, point2};
   std::vector<std::chrono::nanoseconds> durations = {
-      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)
-  };
+      std::chrono::nanoseconds(10), std::chrono::nanoseconds(20), std::chrono::nanoseconds(30)};
   EXPECT_NO_THROW(this->add_points(points, durations));
   ASSERT_FALSE(this->trajectory->is_empty());
   auto trajectory_points = this->trajectory->get_points();


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding the necessary logic for copy constructors and `=` operators in trajectory classes.

<del>Properly implementing a swap function for `CartesianTrajectory` means that we need to be able to to simple set the `reference_frame`. While we offer a setter with pose to apply the transformations, a simple `std::string` setter is also useful and aligns with the `CartesianState` definition.</del>

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

Review by commit due to the formatting commit. I will have to re-write the history on the staging branch on our final PR targeting main/breaking so that we keep it clean in the commit-by-commit sense there.

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->