### PR TITLE
fix: adapt State copy constructor to initialize type from copy object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release Versions
 
 - feat: improve support for transformation matrices (#146)
 - fix: unstable python test (#221)
+- fix: adapt State copy constructor to initialize type from copy object (#225)
 
 ## 9.1.0
 

--- a/source/state_representation/src/State.cpp
+++ b/source/state_representation/src/State.cpp
@@ -11,7 +11,7 @@ State::State(const std::string& name) :
 
 State::State(const State& state) :
     std::enable_shared_from_this<State>(state),
-    type_(StateType::STATE),
+    type_(state.get_type()),
     name_(state.name_),
     empty_(state.empty_),
     timestamp_(state.timestamp_) {}


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #225 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by changing the copy constructor to initialize the type from the copy object.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: x minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->