### PR TITLE
feat: add functionality to create a robot model from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Release Versions
 - feat: implement serialization helpers for trajectory classes (#228)
 - chore: clean up includes (#236)
 - feat: expose pinocchio::Data through getter (#238)
+- feat: add functionality to create a robot model from string (#200)
 
 ## 9.1.0
 

--- a/python/source/robot_model/bind_model.cpp
+++ b/python/source/robot_model/bind_model.cpp
@@ -53,7 +53,7 @@ void model(py::module_& m) {
   c.def("get_robot_name", &Model::get_robot_name, "Getter of the robot name.");
   c.def("set_robot_name", &Model::set_robot_name, "Setter of the robot name.", "robot_name"_a);
   c.def("get_urdf", &Model::get_urdf, "Getter of the URDF XML string.");
-  c.def("get_urdf_path", &Model::get_urdf_path, "Getter of the URDF path.");
+  c.def("get_urdf_path", &Model::get_urdf_path, "Getter of the URDF path if it was provided for construction instead of an XML string.");
   c.def("get_number_of_joints", &Model::get_number_of_joints, "Getter of the number of joints.");
   c.def("get_joint_frames", &Model::get_joint_frames, "Getter of the joint frames of the model.");
   c.def("get_frames", &Model::get_frames, "Getter of the frames of the model.");

--- a/python/source/robot_model/bind_model.cpp
+++ b/python/source/robot_model/bind_model.cpp
@@ -39,11 +39,11 @@ void model(py::module_& m) {
         };
   }
   return new Model(robot_name, urdf_path, callback_cpp);
-  }), "Constructor that creates a robot model instance with a name, URDF path, and an optional custom mesh loader callback. This constructor loads the Robot Geometries.", 
+  }), "Constructor that creates a robot model instance with a name, URDF XML string or path, and an optional custom mesh loader callback. This constructor loads the Robot Geometries.", 
   py::arg("robot_name"), py::arg("urdf_path"), py::arg("meshloader_callback"));
 
 
-  c.def(py::init<const std::string&, const std::string&>(), "Constructor that creates a robot model instance with a name and URDF path. This constructor doesn't loads the Robot Geometries.",
+  c.def(py::init<const std::string&, const std::string&>(), "Constructor that creates a robot model instance with a name and URDF XML string or path. This constructor doesn't loads the Robot Geometries.",
         py::arg("robot_name"),
         py::arg("urdf_path")
   );
@@ -52,6 +52,7 @@ void model(py::module_& m) {
 
   c.def("get_robot_name", &Model::get_robot_name, "Getter of the robot name.");
   c.def("set_robot_name", &Model::set_robot_name, "Setter of the robot name.", "robot_name"_a);
+  c.def("get_urdf", &Model::get_urdf, "Getter of the URDF XML string.");
   c.def("get_urdf_path", &Model::get_urdf_path, "Getter of the URDF path.");
   c.def("get_number_of_joints", &Model::get_number_of_joints, "Getter of the number of joints.");
   c.def("get_joint_frames", &Model::get_joint_frames, "Getter of the joint frames of the model.");

--- a/python/test/model/test_model.py
+++ b/python/test/model/test_model.py
@@ -86,6 +86,7 @@ class TestRobotModel(unittest.TestCase):
                 <link name="foo_link"/>
             </robot>'''
         foo_model = Model("foo", string_urdf)
+        self.assertTrue(foo_model.get_urdf_path() is None)
 
     def test_number_of_joints(self):
         self.assertEqual(self.robot_model.get_number_of_joints(), 7)

--- a/python/test/model/test_model.py
+++ b/python/test/model/test_model.py
@@ -70,6 +70,23 @@ class TestRobotModel(unittest.TestCase):
         self.assertFalse(self.robot_model.get_urdf_path() is None)
         self.assertEqual(self.robot_model.get_urdf_path(), self.urdf_path)
 
+        with self.assertRaises(Exception):
+            foo_model = Model("foo", "invalid_path.urdf")
+
+        invalid_xml = '''
+            <?xml version="1.0"? encoding="UTF-8"?>
+            <robot name="foo">
+            </robot>'''
+        with self.assertRaises(Exception):
+            foo_model = Model("foo", invalid_xml)
+
+        string_urdf = '''
+            <?xml version="1.0"? encoding="UTF-8"?>
+            <robot name="foo">
+                <link name="foo_link"/>
+            </robot>'''
+        foo_model = Model("foo", string_urdf)
+
     def test_number_of_joints(self):
         self.assertEqual(self.robot_model.get_number_of_joints(), 7)
 

--- a/python/test/model/test_model.py
+++ b/python/test/model/test_model.py
@@ -67,6 +67,7 @@ class TestRobotModel(unittest.TestCase):
         self.assertEqual(self.robot_model.get_robot_name(), "robot")
 
     def test_get_urdf_path(self):
+        self.assertFalse(self.robot_model.get_urdf_path() is None)
         self.assertEqual(self.robot_model.get_urdf_path(), self.urdf_path)
 
     def test_number_of_joints(self):

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -68,7 +68,7 @@ private:
 
   /**
    * @brief Initialize the pinocchio geometry model from the URDF and the package paths
-   * @param urdf the URDF string
+   * @param urdf the URDF (XML string or filepath) of the robot
    */
   void init_geom_model(std::string urdf);
 
@@ -194,7 +194,7 @@ public:
    * @details If the URDF contains references to collision geometry meshes, they will not be loaded into memory.
    * To enable collision detection, use the alternate constructor.
    * @param robot_name the name to associate with the model
-   * @param urdf_ the URDF (XML string of filepath) of the robot
+   * @param urdf the URDF (XML string or filepath) of the robot
    * @throws std::runtime_error if the URDF file cannot be loaded or is invalid
    */
   explicit Model(const std::string& robot_name, const std::string& urdf);
@@ -207,7 +207,7 @@ public:
    * the optional meshloader_callback function should be defined to return an absolute path to a package
    * given the package name.
    * @param robot_name the name to associate with the model
-   * @param urdf_ the URDF (XML string) of the robot
+   * @param urdf the URDF (XML string or filepath) of the robot
    * @param meshloader_callback optional callback to resolve the absolute package path from a package name
    */
   explicit Model(
@@ -292,7 +292,7 @@ public:
   const std::string& get_urdf() const;
 
   /**
-   * @brief Getter of the URDF path if it was provided instead of an XML string
+   * @brief Getter of the URDF path if it was provided for construction instead of an XML string
    * @return the URDF path
    */
   std::optional<std::reference_wrapper<const std::string>> get_urdf_path() const;

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -49,7 +49,7 @@ struct InverseKinematicsParameters {
 class Model {
 private:
   std::string robot_name_;         ///< name of the robot
-  std::string urdf_;               ///< urdf file (XML string)
+  std::string urdf_;               ///< urdf (XML string)
   std::string urdf_path_;          ///< path to the urdf file
   std::vector<std::string> frames_;///< name of the frames
   pinocchio::Model robot_model_;   ///< the robot model with pinocchio
@@ -194,7 +194,8 @@ public:
    * @details If the URDF contains references to collision geometry meshes, they will not be loaded into memory.
    * To enable collision detection, use the alternate constructor.
    * @param robot_name the name to associate with the model
-   * @param urdf_ the URDF (XML string) of the robot
+   * @param urdf_ the URDF (XML string of filepath) of the robot
+   * @throws std::runtime_error if the URDF file cannot be loaded or is invalid
    */
   explicit Model(const std::string& robot_name, const std::string& urdf);
 
@@ -291,7 +292,7 @@ public:
   const std::string& get_urdf() const;
 
   /**
-   * @brief Getter of the URDF path
+   * @brief Getter of the URDF path if it was provided instead of an XML string
    * @return the URDF path
    */
   std::optional<std::reference_wrapper<const std::string>> get_urdf_path() const;

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -49,6 +49,7 @@ struct InverseKinematicsParameters {
 class Model {
 private:
   std::string robot_name_;         ///< name of the robot
+  std::string urdf_;               ///< urdf file (XML string)
   std::string urdf_path_;          ///< path to the urdf file
   std::vector<std::string> frames_;///< name of the frames
   pinocchio::Model robot_model_;   ///< the robot model with pinocchio
@@ -67,6 +68,7 @@ private:
 
   /**
    * @brief Initialize the pinocchio geometry model from the URDF and the package paths
+   * @param urdf the URDF string
    */
   void init_geom_model(std::string urdf);
 
@@ -192,9 +194,9 @@ public:
    * @details If the URDF contains references to collision geometry meshes, they will not be loaded into memory.
    * To enable collision detection, use the alternate constructor.
    * @param robot_name the name to associate with the model
-   * @param urdf_path the path to the URDF file
+   * @param urdf_ the URDF (XML string) of the robot
    */
-  explicit Model(const std::string& robot_name, const std::string& urdf_path);
+  explicit Model(const std::string& robot_name, const std::string& urdf);
 
   /**
    * @brief Construct a robot model with collision geometries from a URDF file
@@ -204,11 +206,11 @@ public:
    * the optional meshloader_callback function should be defined to return an absolute path to a package
    * given the package name.
    * @param robot_name the name to associate with the model
-   * @param urdf_path the path to the URDF file
+   * @param urdf_ the URDF (XML string) of the robot
    * @param meshloader_callback optional callback to resolve the absolute package path from a package name
    */
   explicit Model(
-      const std::string& robot_name, const std::string& urdf_path,
+      const std::string& robot_name, const std::string& urdf,
       const std::optional<std::function<std::string(const std::string&)>>& meshloader_callback
   );
 
@@ -283,10 +285,16 @@ public:
   void set_robot_name(const std::string& robot_name);
 
   /**
+   * @brief Getter of the URDF string
+   * @return the URDF
+   */
+  const std::string& get_urdf() const;
+
+  /**
    * @brief Getter of the URDF path
    * @return the URDF path
    */
-  const std::string& get_urdf_path() const;
+  std::optional<std::reference_wrapper<const std::string>> get_urdf_path() const;
 
   /**
    * @brief Getter of the number of joints
@@ -593,6 +601,7 @@ inline const std::string& Model::get_robot_name() const {
 inline void swap(Model& first, Model& second) {
   using std::swap;
   swap(first.robot_name_, second.robot_name_);
+  swap(first.urdf_, second.urdf_);
   swap(first.urdf_path_, second.urdf_path_);
   swap(first.frames_, second.frames_);
   swap(first.robot_model_, second.robot_model_);
@@ -614,8 +623,16 @@ inline void Model::set_robot_name(const std::string& robot_name) {
   this->robot_name_ = robot_name;
 }
 
-inline const std::string& Model::get_urdf_path() const {
-  return this->urdf_path_;
+inline const std::string& Model::get_urdf() const {
+  return this->urdf_;
+}
+
+inline std::optional<std::reference_wrapper<const std::string>> Model::get_urdf_path() const {
+  if (this->urdf_path_.empty()) {
+    return std::nullopt;
+  } else {
+    return this->urdf_path_;
+  }
 }
 
 inline unsigned int Model::get_number_of_joints() const {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -5,6 +5,7 @@
 
 #include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
+#include <stdexcept>
 
 #include "robot_model/exceptions/CollisionGeometryException.hpp"
 #include "robot_model/exceptions/FrameNotFoundException.hpp"
@@ -97,12 +98,11 @@ void Model::init_model() {
     this->urdf_ = buffer.str();
   }
 
-  pinocchio::urdf::buildModelFromXML(this->urdf_, this->robot_model_);
-  // todo: are we ok with potentially leaving empty models go through this point?
-  // todo: if urdf_ is empty here, pinocchio will still return an empty model which will eventually break things
-  //   if (this->robot_model_.nq == 0) {
-  //     throw std::runtime_error("Failed to initialize model from URDF");
-  //   }
+  try {
+    pinocchio::urdf::buildModelFromXML(this->urdf_, this->robot_model_);
+  } catch (const std::invalid_argument& ex) {
+    throw std::runtime_error("Failed to initialize model from URDF: " + std::string(ex.what()));
+  }
   this->robot_data_ = pinocchio::Data(this->robot_model_);
 
   if (this->load_collision_geometries_) {

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -45,6 +45,28 @@ TEST_F(RobotModelTest, TestGetUrdfPath) {
   auto path = franka->get_urdf_path();
   ASSERT_TRUE(path.has_value());
   EXPECT_STREQ(path->get().c_str(), urdf_path.c_str());
+
+  EXPECT_THROW(std::make_unique<Model>("invalid_path", "invalid_path.urdf"), std::runtime_error);
+
+  // clang-format off
+  auto invalid_xml = 
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<robot name=\"foo\">"
+    "</robot>";
+  // clang-format on
+  EXPECT_THROW(std::make_unique<Model>("invalid_path", invalid_xml), std::runtime_error);
+
+  // clang-format off
+  auto string_urdf = 
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    "<robot name=\"foo\">"
+    "  <link name=\"foo_link\"/>"
+    "</robot>";
+  // clang-format on
+  std::unique_ptr<Model> foo;
+  EXPECT_NO_THROW(foo = std::make_unique<Model>("invalid_path", string_urdf));
+  auto path2 = foo->get_urdf_path();
+  ASSERT_FALSE(path2.has_value());
 }
 
 TEST_F(RobotModelTest, TestCopyConstructor) {

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -64,7 +64,7 @@ TEST_F(RobotModelTest, TestGetUrdfPath) {
     "</robot>";
   // clang-format on
   std::unique_ptr<Model> foo;
-  EXPECT_NO_THROW(foo = std::make_unique<Model>("invalid_path", string_urdf));
+  EXPECT_NO_THROW(foo = std::make_unique<Model>("string_urdf", string_urdf));
   auto path2 = foo->get_urdf_path();
   ASSERT_FALSE(path2.has_value());
 }

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -42,7 +42,9 @@ TEST_F(RobotModelTest, TestSetName) {
 }
 
 TEST_F(RobotModelTest, TestGetUrdfPath) {
-  EXPECT_EQ(franka->get_urdf_path(), urdf_path);
+  auto path = franka->get_urdf_path();
+  ASSERT_TRUE(path.has_value());
+  EXPECT_STREQ(path->get().c_str(), urdf_path.c_str());
 }
 
 TEST_F(RobotModelTest, TestCopyConstructor) {


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #200 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by refactoring the model class to now hold both a `urdf_` and a `urdf_path_` member variable. The implemented logic is that we don't change the current interface, but try to load the urdf as a path and if that fails we try to use it as an XML to build the model (this creates a side effect, see comments).

I am opening this PR for visibility  but I expect that we should discuss the direction a bit more.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->