### PR TITLE
feat(communication-interfaces): add timeout setter for udp sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Release Versions
 - feat: improve devcontainer configuration (#230)
 - chore: format code (#235)
 - ci: allow workflow dispatch for rc images (#234)
+- feat: add timeout setter for udp sockets (#728)
 
 ## 9.1.0
 

--- a/python/source/communication_interfaces/bind_udp.cpp
+++ b/python/source/communication_interfaces/bind_udp.cpp
@@ -18,9 +18,9 @@ void bind_udp(py::module_& m) {
 
   py::class_<UDPClient, std::shared_ptr<UDPClient>, ISocket>(m, "UDPClient")
       .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a),
-      .def("set_timeout", &sockets::UDPClient::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
+      .def("set_timeout", &UDPClient::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
 
   py::class_<UDPServer, std::shared_ptr<UDPServer>, ISocket>(m, "UDPServer")
       .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a)
-      .def("set_timeout", &sockets::UDPServer::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
+      .def("set_timeout", &UDPServer::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
 }

--- a/python/source/communication_interfaces/bind_udp.cpp
+++ b/python/source/communication_interfaces/bind_udp.cpp
@@ -17,7 +17,7 @@ void bind_udp(py::module_& m) {
       .def_readwrite("timeout_duration_sec", &UDPSocketConfiguration::timeout_duration_sec);
 
   py::class_<UDPClient, std::shared_ptr<UDPClient>, ISocket>(m, "UDPClient")
-      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a),
+      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a)
       .def("set_timeout", &UDPClient::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
 
   py::class_<UDPServer, std::shared_ptr<UDPServer>, ISocket>(m, "UDPServer")

--- a/python/source/communication_interfaces/bind_udp.cpp
+++ b/python/source/communication_interfaces/bind_udp.cpp
@@ -17,8 +17,10 @@ void bind_udp(py::module_& m) {
       .def_readwrite("timeout_duration_sec", &UDPSocketConfiguration::timeout_duration_sec);
 
   py::class_<UDPClient, std::shared_ptr<UDPClient>, ISocket>(m, "UDPClient")
-      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a);
+      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a),
+      .def("set_timeout", &sockets::UDPClient::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
 
   py::class_<UDPServer, std::shared_ptr<UDPServer>, ISocket>(m, "UDPServer")
-      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a);
+      .def(py::init<UDPSocketConfiguration>(), "Constructor taking the configuration struct", "configuration"_a)
+      .def("set_timeout", &sockets::UDPServer::set_timeout, "Set the timeout of the socket", "timeout_duration_sec"_a);
 }

--- a/python/test/communication_interfaces/test_udp.py
+++ b/python/test/communication_interfaces/test_udp.py
@@ -49,6 +49,7 @@ def test_timeout(udp_config):
     server.open()
 
     assert server.receive_bytes() is None
+    server.set_timeout(1.0)
     server.close()
 
 

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -30,8 +30,9 @@ public:
   ~UDPSocket() override;
 
   /**
-   * @brief Set the timeout of the socket.
+   * @brief Set the timeout of the socket
    * @param timeout_duration_sec The desired timeout in seconds
+   * @throws SocketConfigurationException if the timeout could not be set
    */
   void set_timeout(double timeout_duration_sec);
 

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -29,6 +29,12 @@ public:
    */
   ~UDPSocket() override;
 
+  /**
+   * @brief Set the timeout of the socket.
+   * @param timeout_duration_sec The desired timeout in seconds
+   */
+  void set_timeout(double timeout_duration_sec);
+
 protected:
   /**
    * @brief Constructor taking the configuration struct

--- a/source/communication_interfaces/test/tests/test_udp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_udp_communication.cpp
@@ -44,6 +44,7 @@ TEST_F(TestUDPSockets, Timeout) {
   // Try to receive a message from client, but expect timeout
   std::string received_bytes;
   EXPECT_FALSE(server.receive_bytes(received_bytes));
+  EXPECT_NO_THROW(server.set_timeout(1.0));
 }
 
 TEST_F(TestUDPSockets, PortReuse) {


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR adds the possibility to set the timeout of a UDP socket after construction. This can for example be used to have a different timeout between a server waiting for a connection and then subsequent recv calls.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->