### PR TITLE
feat!: rename set_parameter_value to set_parameter and add strict parameter map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release Versions
 ## Upcoming changes
 
 - fix: raise exception when accessing an empty parameter value in python (#260)
+- feat!: rename set_parameter_value to set_parameter and add strict parameter map (#259)
 
 ## 9.3.1
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 # Control Libraries
 
+:warning: Control libraries are currently undergoing breaking changes and the main branch may not be stable until the
+next official release! :warning:
+
 The `control-libraries` project is a collection of modules to facilitate the creation of control loop algorithms for
 robotics, including trajectory planning, kinematics, dynamics and control.
 

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -167,6 +167,12 @@ void parameter_map(py::module_& m) {
   c.def("set_parameter", [](ParameterMap& self, const ParameterContainer& parameter) {
     self.set_parameter(container_to_interface_ptr(parameter));
   }, "Set a parameter", "parameter"_a);
+  c.def(
+      "set_parameter", [](ParameterMap& self, const std::string& name, const py::object& value, const ParameterType& type, const StateType& parameter_state_type) -> void {
+        auto param = ParameterContainer(name, value, type, parameter_state_type);
+        self.set_parameter(container_to_interface_ptr(param));
+      }, "Set a parameter value by its name", "name"_a, "value"_a, "type"_a, "parameter_state_type"_a=StateType::NONE
+  );
   c.def("set_parameters", [](ParameterMap& self, const std::list<ParameterContainer>& parameters) {
     self.set_parameters(container_to_interface_ptr_list(parameters));
   }, "Set parameters from a list of parameters", "parameters"_a);
@@ -175,6 +181,7 @@ void parameter_map(py::module_& m) {
   }, "Set parameters from a map with <name, parameter> pairs", "parameters"_a);
   c.def(
       "set_parameter_value", [](ParameterMap& self, const std::string& name, const py::object& value, const ParameterType& type, const StateType& parameter_state_type) -> void {
+        PyErr_WarnEx(PyExc_DeprecationWarning, "set_parameter_value(name, value) is deprecated, use set_parameter(name, value) instead.", 1);
         auto param = ParameterContainer(name, value, type, parameter_state_type);
         self.set_parameter(container_to_interface_ptr(param));
       }, "Set a parameter value by its name", "name"_a, "value"_a, "type"_a, "parameter_state_type"_a=StateType::NONE

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -179,13 +179,6 @@ void parameter_map(py::module_& m) {
   c.def("set_parameters", [](ParameterMap& self, const std::map<std::string, ParameterContainer>& parameters) {
     self.set_parameters(container_to_interface_ptr_map(parameters));
   }, "Set parameters from a map with <name, parameter> pairs", "parameters"_a);
-  c.def(
-      "set_parameter_value", [](ParameterMap& self, const std::string& name, const py::object& value, const ParameterType& type, const StateType& parameter_state_type) -> void {
-        PyErr_WarnEx(PyExc_DeprecationWarning, "set_parameter_value(name, value) is deprecated, use set_parameter(name, value) instead.", 1);
-        auto param = ParameterContainer(name, value, type, parameter_state_type);
-        self.set_parameter(container_to_interface_ptr(param));
-      }, "Set a parameter value by its name", "name"_a, "value"_a, "type"_a, "parameter_state_type"_a=StateType::NONE
-  );
   c.def("remove_parameter", &ParameterMap::remove_parameter, "Remove a parameter from the parameter map.", "name"_a);
 }
 

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -171,7 +171,7 @@ void parameter_map(py::module_& m) {
       "set_parameter", [](ParameterMap& self, const std::string& name, const py::object& value, const ParameterType& type, const StateType& parameter_state_type) -> void {
         auto param = ParameterContainer(name, value, type, parameter_state_type);
         self.set_parameter(container_to_interface_ptr(param));
-      }, "Set a parameter value by its name", "name"_a, "value"_a, "type"_a, "parameter_state_type"_a=StateType::NONE
+      }, "Set a parameter by name and value", "name"_a, "value"_a, "type"_a, "parameter_state_type"_a=StateType::NONE
   );
   c.def("set_parameters", [](ParameterMap& self, const std::list<ParameterContainer>& parameters) {
     self.set_parameters(container_to_interface_ptr_list(parameters));

--- a/python/test/controllers/test_compliant_twist.py
+++ b/python/test/controllers/test_compliant_twist.py
@@ -18,10 +18,10 @@ class TestCompliantTwistController(unittest.TestCase):
 
     @classmethod
     def set_gains(cls, lpd, lod, ast, ad):
-        cls.ctrl.set_parameter_value("linear_principle_damping", lpd, sr.ParameterType.DOUBLE)
-        cls.ctrl.set_parameter_value("linear_orthogonal_damping", lod, sr.ParameterType.DOUBLE)
-        cls.ctrl.set_parameter_value("angular_stiffness", ast, sr.ParameterType.DOUBLE)
-        cls.ctrl.set_parameter_value("angular_damping", ad, sr.ParameterType.DOUBLE)
+        cls.ctrl.set_parameter("linear_principle_damping", lpd, sr.ParameterType.DOUBLE)
+        cls.ctrl.set_parameter("linear_orthogonal_damping", lod, sr.ParameterType.DOUBLE)
+        cls.ctrl.set_parameter("angular_stiffness", ast, sr.ParameterType.DOUBLE)
+        cls.ctrl.set_parameter("angular_damping", ad, sr.ParameterType.DOUBLE)
 
     # FIXME this line sometimes fails with github actions
     # def test_cartesian_wrench(self):
@@ -50,22 +50,22 @@ class TestCompliantTwistController(unittest.TestCase):
             if param.get_name() == "linear_principle_damping":
                 self.assertTrue(abs(param.get_value() - 1) < 1e-5)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("linear_principle_damping") - 1) < 1e-5)
-                self.ctrl.set_parameter_value("linear_principle_damping", 11, sr.ParameterType.DOUBLE)
+                self.ctrl.set_parameter("linear_principle_damping", 11, sr.ParameterType.DOUBLE)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("linear_principle_damping") - 11) < 1e-5)
             if param.get_name() == "linear_orthogonal_damping":
                 self.assertTrue(abs(param.get_value() - 2) < 1e-5)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("linear_orthogonal_damping") - 2) < 1e-5)
-                self.ctrl.set_parameter_value("linear_orthogonal_damping", 12, sr.ParameterType.DOUBLE)
+                self.ctrl.set_parameter("linear_orthogonal_damping", 12, sr.ParameterType.DOUBLE)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("linear_orthogonal_damping") - 12) < 1e-5)
             if param.get_name() == "angular_stiffness":
                 self.assertTrue(abs(param.get_value() - 3) < 1e-5)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("angular_stiffness") - 3) < 1e-5)
-                self.ctrl.set_parameter_value("angular_stiffness", 13, sr.ParameterType.DOUBLE)
+                self.ctrl.set_parameter("angular_stiffness", 13, sr.ParameterType.DOUBLE)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("angular_stiffness") - 13) < 1e-5)
             if param.get_name() == "angular_damping":
                 self.assertTrue(abs(param.get_value() - 4) < 1e-5)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("angular_damping") - 4) < 1e-5)
-                self.ctrl.set_parameter_value("angular_damping", 14, sr.ParameterType.DOUBLE)
+                self.ctrl.set_parameter("angular_damping", 14, sr.ParameterType.DOUBLE)
                 self.assertTrue(abs(self.ctrl.get_parameter_value("angular_damping") - 14) < 1e-5)
 
 

--- a/python/test/controllers/test_controller.py
+++ b/python/test/controllers/test_controller.py
@@ -15,8 +15,7 @@ CONTROLLER_METHOD_EXPECTS = [
     'get_parameter_value',
     'get_parameter_list',
     'set_parameter',
-    'set_parameters',
-    'set_parameter_value'
+    'set_parameters'
 ]
 
 

--- a/python/test/controllers/test_dissipative_impedance.py
+++ b/python/test/controllers/test_dissipative_impedance.py
@@ -13,7 +13,7 @@ class TestDissipativeImpedance(unittest.TestCase):
 
         eigenvalues = ctrl.get_parameter_value("damping_eigenvalues")
         eigenvalues[0] = 10
-        ctrl.set_parameter_value("damping_eigenvalues", eigenvalues, sr.ParameterType.VECTOR)
+        ctrl.set_parameter("damping_eigenvalues", eigenvalues, sr.ParameterType.VECTOR)
 
         desired_twist = sr.CartesianTwist("test", [1, 0, 0])
         feedback_twist = sr.CartesianTwist("test", [1, 1, 0])

--- a/python/test/state_representation/test_parameters.py
+++ b/python/test/state_representation/test_parameters.py
@@ -108,7 +108,7 @@ def test_param_map():
 
     m = sr.ParameterMap()
     for name, param in param_dict.items():
-        m.set_parameter_value(param.get_name(), param.get_value(), param.get_parameter_type(),
+        m.set_parameter(param.get_name(), param.get_value(), param.get_parameter_type(),
                               param.get_parameter_state_type())
     param_map_equal(param_dict, m)
 

--- a/source/controllers/README.md
+++ b/source/controllers/README.md
@@ -99,7 +99,7 @@ methods:
 - `get_parameter_value<T>(name)`
 - `set_parameters(parameters)`
 - `set_parameter(parameter)`
-- `set_parameter_value(name, value)`
+- `set_parameter(name, value)`
 
 These methods can be used after construction to get or set controller parameters. Refer to the documentation
 on `controllers::IController<>` and `state_representation::ParameterMap` for more information.

--- a/source/controllers/src/impedance/CompliantTwist.cpp
+++ b/source/controllers/src/impedance/CompliantTwist.cpp
@@ -47,7 +47,7 @@ void CompliantTwist::set_linear_gains(double linear_principle_damping, double li
 
   Eigen::VectorXd damping(6);
   damping << linear_principle_damping, linear_orthogonal_damping, linear_orthogonal_damping, 0, 0, 0;
-  dissipative_ctrl_.set_parameter_value("damping_eigenvalues", damping);
+  dissipative_ctrl_.set_parameter("damping_eigenvalues", damping);
 }
 
 void CompliantTwist::set_angular_stiffness(double angular_stiffness) {
@@ -66,8 +66,8 @@ void CompliantTwist::set_angular_gains(double angular_stiffness, double angular_
   Eigen::MatrixXd d = Eigen::MatrixXd::Zero(6, 6);
   k.diagonal() << 0, 0, 0, angular_stiffness, angular_stiffness, angular_stiffness;
   d.diagonal() << 0, 0, 0, angular_damping, angular_damping, angular_damping;
-  velocity_impedance_ctrl_.set_parameter_value("stiffness", k);
-  velocity_impedance_ctrl_.set_parameter_value("damping", d);
+  velocity_impedance_ctrl_.set_parameter("stiffness", k);
+  velocity_impedance_ctrl_.set_parameter("damping", d);
 }
 
 CartesianState

--- a/source/controllers/test/tests/test_compliant_twist_controller.cpp
+++ b/source/controllers/test/tests/test_compliant_twist_controller.cpp
@@ -16,10 +16,10 @@ protected:
   }
 
   void set_gains(double lpd, double lod, double as, double ad) {
-    controller_->set_parameter_value("linear_principle_damping", lpd);
-    controller_->set_parameter_value("linear_orthogonal_damping", lod);
-    controller_->set_parameter_value("angular_stiffness", as);
-    controller_->set_parameter_value("angular_damping", ad);
+    controller_->set_parameter("linear_principle_damping", lpd);
+    controller_->set_parameter("linear_orthogonal_damping", lod);
+    controller_->set_parameter("angular_stiffness", as);
+    controller_->set_parameter("angular_damping", ad);
   }
 
   std::shared_ptr<IController<CartesianState>> controller_;
@@ -61,28 +61,28 @@ TEST_F(CompliantTwistControllerTest, GetAndSetParameters) {
       EXPECT_NEAR(controller_->get_parameter_value<double>("linear_principle_damping"), 1, 1e-5);
       param->set_value(11);
       EXPECT_NEAR(controller_->get_parameter_value<double>("linear_principle_damping"), 11, 1e-5);
-      controller_->set_parameter_value<double>("linear_principle_damping", 21);
+      controller_->set_parameter<double>("linear_principle_damping", 21);
       EXPECT_NEAR(param->get_value(), 21, 1e-5);
     } else if (param->get_name() == "linear_orthogonal_damping") {
       EXPECT_NEAR(param->get_value(), 2, 1e-5);
       EXPECT_NEAR(controller_->get_parameter_value<double>("linear_orthogonal_damping"), 2, 1e-5);
       param->set_value(12);
       EXPECT_NEAR(controller_->get_parameter_value<double>("linear_orthogonal_damping"), 12, 1e-5);
-      controller_->set_parameter_value<double>("linear_orthogonal_damping", 22);
+      controller_->set_parameter<double>("linear_orthogonal_damping", 22);
       EXPECT_NEAR(param->get_value(), 22, 1e-5);
     } else if (param->get_name() == "angular_stiffness") {
       EXPECT_NEAR(param->get_value(), 3, 1e-5);
       EXPECT_NEAR(controller_->get_parameter_value<double>("angular_stiffness"), 3, 1e-5);
       param->set_value(13);
       EXPECT_NEAR(controller_->get_parameter_value<double>("angular_stiffness"), 13, 1e-5);
-      controller_->set_parameter_value<double>("angular_stiffness", 23);
+      controller_->set_parameter<double>("angular_stiffness", 23);
       EXPECT_NEAR(param->get_value(), 23, 1e-5);
     } else if (param->get_name() == "angular_damping") {
       EXPECT_NEAR(param->get_value(), 4, 1e-5);
       EXPECT_NEAR(controller_->get_parameter_value<double>("angular_damping"), 4, 1e-5);
       param->set_value(14);
       EXPECT_NEAR(controller_->get_parameter_value<double>("angular_damping"), 14, 1e-5);
-      controller_->set_parameter_value<double>("angular_damping", 24);
+      controller_->set_parameter<double>("angular_damping", 24);
       EXPECT_NEAR(param->get_value(), 24, 1e-5);
     }
   }

--- a/source/controllers/test/tests/test_dissipative_impedance.cpp
+++ b/source/controllers/test/tests/test_dissipative_impedance.cpp
@@ -195,7 +195,7 @@ TEST(DissipativeControllerTest, TestComputeCommandWithColinearVelocity) {
   // set different damping
   auto eigenvalues = controller->get_parameter_value<Eigen::VectorXd>("damping_eigenvalues");
   eigenvalues(0) = 10.0;
-  controller->set_parameter_value("damping_eigenvalues", eigenvalues);
+  controller->set_parameter("damping_eigenvalues", eigenvalues);
 
   // set a desired and feeadback velocity
   CartesianTwist desired_twist("test", Eigen::Vector3d(1, 0, 0));

--- a/source/controllers/test/tests/test_impedance.cpp
+++ b/source/controllers/test/tests/test_impedance.cpp
@@ -68,7 +68,7 @@ TEST(ImpedanceControllerTest, TestCartesianImpedanceLimits) {
 
   // set a scalar force limit
   double limit = 1.0;
-  EXPECT_NO_THROW(controller->set_parameter_value("force_limit", limit));
+  EXPECT_NO_THROW(controller->set_parameter("force_limit", limit));
   // expect all degrees of freedom to have the same force limit
   command = controller->compute_command(desired_state, feedback_state);
   for (int index = 0; index < 6; ++index) {
@@ -77,7 +77,7 @@ TEST(ImpedanceControllerTest, TestCartesianImpedanceLimits) {
 
   // set a force limit on each degree of freedom
   std::vector<double> limits = {0.5, 1.0, 1.5, 2.0, 3.5, 4.0};
-  EXPECT_NO_THROW(controller->set_parameter_value("force_limit", limits));
+  EXPECT_NO_THROW(controller->set_parameter("force_limit", limits));
 
   // expect all degrees of freedom to respect the individual force limits
   command = controller->compute_command(desired_state, feedback_state);
@@ -87,7 +87,7 @@ TEST(ImpedanceControllerTest, TestCartesianImpedanceLimits) {
 
   // ensure the limit must match the degrees of freedom
   EXPECT_THROW(
-      controller->set_parameter_value("force_limit", std::vector<double>({1.0, 2.0})),
+      controller->set_parameter("force_limit", std::vector<double>({1.0, 2.0})),
       state_representation::exceptions::IncompatibleSizeException
   );
 }
@@ -128,7 +128,7 @@ TEST(ImpedanceControllerTest, TestJointImpedanceLimits) {
 
   // set a scalar force limit
   double limit = 1.0;
-  EXPECT_NO_THROW(controller->set_parameter_value("force_limit", limit));
+  EXPECT_NO_THROW(controller->set_parameter("force_limit", limit));
   // expect all degrees of freedom to have the same force limit
   command = controller->compute_command(desired_state, feedback_state);
   for (int index = 0; index < nb_joints; ++index) {
@@ -137,7 +137,7 @@ TEST(ImpedanceControllerTest, TestJointImpedanceLimits) {
 
   // set a force limit on each degree of freedom
   std::vector<double> limits = {0.5, 1.0, 1.5};
-  EXPECT_NO_THROW(controller->set_parameter_value("force_limit", limits));
+  EXPECT_NO_THROW(controller->set_parameter("force_limit", limits));
 
   // expect all degrees of freedom to respect the individual force limits
   command = controller->compute_command(desired_state, feedback_state);
@@ -147,7 +147,7 @@ TEST(ImpedanceControllerTest, TestJointImpedanceLimits) {
 
   // ensure the limit must match the degrees of freedom
   EXPECT_THROW(
-      controller->set_parameter_value("force_limit", std::vector<double>({1.0, 2.0})),
+      controller->set_parameter("force_limit", std::vector<double>({1.0, 2.0})),
       state_representation::exceptions::IncompatibleSizeException
   );
 }

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -81,7 +81,7 @@ methods:
 - `get_parameter_value<T>(name)`
 - `set_parameters(parameters)`
 - `set_parameter(parameter)`
-- `set_parameter(name, value)` (deprecated as of v9.4.0)
+- `set_parameter_value(name, value)` (deprecated as of v9.4.0)
 - `set_parameter(name, value)`
 
 These methods can be used after construction to get or set dynamical system parameters. Refer to the documentation

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -81,7 +81,8 @@ methods:
 - `get_parameter_value<T>(name)`
 - `set_parameters(parameters)`
 - `set_parameter(parameter)`
-- `set_parameter_value(name, value)`
+- `set_parameter(name, value)` (deprecated as of v9.4.0)
+- `set_parameter(name, value)`
 
 These methods can be used after construction to get or set dynamical system parameters. Refer to the documentation
 on `dynamical_systems::IDynamicalSystem<S>` and `state_representation::ParameterMap` for more
@@ -328,14 +329,14 @@ length, or as a scalar (which sets the value along the diagonal elements of the 
 ```c++
 // set a gain (scalar, vector or matrix)
 double gain = 10;
-ds->set_parameter_value("gain", gain);
+ds->set_parameter("gain", gain);
 // or
 std::vector<double> gains = {1, 2, 3, 4, 5, 6};
-ds->set_parameter_value("gain", gain);
+ds->set_parameter("gain", gain);
 
 // update the attractor
 state_representation::CartesianState csB = state_representation::CartesianState::Random("B");
-ds->set_parameter_value("attractor", csB);
+ds->set_parameter("attractor", csB);
 ```
 
 ### Evaluating the Point Attractor DS
@@ -345,7 +346,7 @@ To get the velocity from a state, simply call the `evaluate()` function.
 ```c++
 auto ds = CartesianDynamicalSystemFactory::create_dynamical_system(DYNAMICAL_SYSTEM_TYPE::POINT_ATTRACTOR);
 state_representation::CartesianState csA = state_representation::CartesianState::Identity("A");
-ds->set_parameter_value("attractor", csA);
+ds->set_parameter("attractor", csA);
 
 state_representation::CartesianState csB = state_representation::CartesianState::Random("B");
 // note: the return type of evaluate() is a CartesianState, but
@@ -395,13 +396,13 @@ double radius = 2.0;
 state_representation::Ellipsoid ellipse("limit_cycle");
 ellipse.set_center_state(center);
 ellipse.set_axis_lengths({radius, 2 * radius});
-ds->set_parameter_value("limit_cycle", ellipse);
+ds->set_parameter("limit_cycle", ellipse);
 
 double planar_gain = 1.0;
-ds->set_parameter_value("planar_gain", planar_gain);
+ds->set_parameter("planar_gain", planar_gain);
 
 double circular_velocity = M_PI / 2;
-ds->set_parameter_value("circular_velocity", circular_velocity);
+ds->set_parameter("circular_velocity", circular_velocity);
 ```
 
 ## Ring
@@ -442,17 +443,17 @@ The constructor takes additional optional arguments to define the ring DS parame
 ```c++
 // update the ring DS parameters
 state_representation::CartesianState center = state_representation::CartesianState::Identity("center");
-ds->set_parameter_value("center", center);
+ds->set_parameter("center", center);
 double radius = 1.0;
-ds->set_parameter_value("radius", radius);
+ds->set_parameter("radius", radius);
 double width = 0.5;
-ds->set_parameter_value("width", width);
+ds->set_parameter("width", width);
 double speed = 1.0;
-ds->set_parameter_value("speed", speed);
+ds->set_parameter("speed", speed);
 double field_strength = 1.0;
-ds->set_parameter_value("field_strength", field_strength);
+ds->set_parameter("field_strength", field_strength);
 double normal_gain = 1.0;
-ds->set_parameter_value("normal_gain", normal_gain);
+ds->set_parameter("normal_gain", normal_gain);
 double angular_gain = 1.0;
-ds->set_parameter_value("angular_gain", angular_gain);
+ds->set_parameter("angular_gain", angular_gain);
 ```

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -81,7 +81,6 @@ methods:
 - `get_parameter_value<T>(name)`
 - `set_parameters(parameters)`
 - `set_parameter(parameter)`
-- `set_parameter_value(name, value)` (deprecated as of v9.4.0)
 - `set_parameter(name, value)`
 
 These methods can be used after construction to get or set dynamical system parameters. Refer to the documentation

--- a/source/dynamical_systems/src/PointAttractor.cpp
+++ b/source/dynamical_systems/src/PointAttractor.cpp
@@ -150,6 +150,8 @@ void PointAttractor<CartesianState>::validate_and_set_parameter(const std::share
       this->set_attractor(parameter->get_parameter_value<CartesianState>());
     } else if (parameter->get_parameter_state_type() == StateType::CARTESIAN_POSE) {
       this->set_attractor(parameter->get_parameter_value<CartesianPose>());
+    } else {
+      throw state_representation::exceptions::InvalidParameterException("Parameter 'attractor' has incorrect type");
     }
   } else if (parameter->get_name() == "gain") {
     this->set_gain(parameter, 6);

--- a/source/dynamical_systems/test/tests/test_circular.cpp
+++ b/source/dynamical_systems/test/tests/test_circular.cpp
@@ -33,7 +33,7 @@ protected:
 };
 
 TEST_F(CircularDSTest, TestPositionOnRadius) {
-  ds->set_parameter_value("limit_cycle", limit_cycle);
+  ds->set_parameter("limit_cycle", limit_cycle);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -49,7 +49,7 @@ TEST_F(CircularDSTest, EmptyConstructor) {
   EXPECT_TRUE(ds->get_parameter_value<Ellipsoid>("limit_cycle").is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
 
-  ds->set_parameter_value("limit_cycle", limit_cycle);
+  ds->set_parameter("limit_cycle", limit_cycle);
   EXPECT_FALSE(ds->get_parameter_value<Ellipsoid>("limit_cycle").is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -73,7 +73,7 @@ TEST_F(CircularDSTest, EvaluateCompatibility) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter_value("limit_cycle", limit_cycle);
+  ds->set_parameter("limit_cycle", limit_cycle);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -83,7 +83,7 @@ TEST_F(CircularDSTest, EvaluateCompatibility) {
 TEST_F(CircularDSTest, TestPositionOnRadiusRandomCenter) {
   limit_cycle.set_center_position(Eigen::Vector3d::Random());
   limit_cycle.set_center_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter_value("limit_cycle", limit_cycle);
+  ds->set_parameter("limit_cycle", limit_cycle);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     state_representation::CartesianTwist twist = ds->evaluate(current_pose);
@@ -100,7 +100,7 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
   auto CinA = CartesianState::Identity("C", "A");
   auto CinB = CartesianState::Identity("C", "B");
 
-  ds->set_parameter_value("limit_cycle", cycle);
+  ds->set_parameter("limit_cycle", cycle);
   EXPECT_STREQ(
       ds->get_parameter_value<Ellipsoid>("limit_cycle").get_center_pose().get_name().c_str(), BinA.get_name().c_str()
   );
@@ -115,10 +115,10 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
 
   // setting the center is only valid if it matches the base reference frame
   cycle.set_center_state(CinA);
-  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", cycle));
+  EXPECT_NO_THROW(ds->set_parameter("limit_cycle", cycle));
   auto cycle2 = Ellipsoid::Unit("C", "B");
   EXPECT_THROW(
-      ds->set_parameter_value("limit_cycle", cycle2),
+      ds->set_parameter("limit_cycle", cycle2),
       state_representation::exceptions::IncompatibleReferenceFramesException
   );
 
@@ -133,12 +133,12 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
 
   // now the base frame is C, setting a center should only work if the reference frame of the center is also C
   EXPECT_THROW(
-      ds->set_parameter_value("limit_cycle", cycle),
+      ds->set_parameter("limit_cycle", cycle),
       state_representation::exceptions::IncompatibleReferenceFramesException
   );
-  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", cycle2));
+  EXPECT_NO_THROW(ds->set_parameter("limit_cycle", cycle2));
   EXPECT_THROW(
-      ds->set_parameter_value("limit_cycle", Ellipsoid("B", "C")), state_representation::exceptions::EmptyStateException
+      ds->set_parameter("limit_cycle", Ellipsoid("B", "C")), state_representation::exceptions::EmptyStateException
   );
-  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", Ellipsoid::Unit("B", "C")));
+  EXPECT_NO_THROW(ds->set_parameter("limit_cycle", Ellipsoid::Unit("B", "C")));
 }

--- a/source/dynamical_systems/test/tests/test_point_attractor.cpp
+++ b/source/dynamical_systems/test/tests/test_point_attractor.cpp
@@ -46,7 +46,7 @@ TEST_F(PointAttractorTest, EmptyConstructorCartesianState) {
   // base frame and attractor should be empty
   EXPECT_TRUE(ds->get_parameter_value<CartesianState>("attractor").is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
-  ds->set_parameter_value<CartesianState>("attractor", attractor);
+  ds->set_parameter<CartesianState>("attractor", attractor);
   EXPECT_FALSE(ds->get_parameter_value<CartesianState>("attractor").is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -70,7 +70,7 @@ TEST_F(PointAttractorTest, EmptyIsCompatible) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter_value("attractor", CartesianState::Identity("CAttractor", "A"));
+  ds->set_parameter("attractor", CartesianState::Identity("CAttractor", "A"));
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -83,7 +83,7 @@ TEST_F(PointAttractorTest, IsCompatible) {
   CartesianState state3("C", "D");
 
   CartesianPose attractor_frame = CartesianPose::Identity("CAttractor", "A");
-  ds->set_parameter_value<CartesianState>("attractor", attractor_frame);
+  ds->set_parameter<CartesianState>("attractor", attractor_frame);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_FALSE(ds->is_compatible(state3));
@@ -99,7 +99,7 @@ TEST_F(PointAttractorTest, IsCompatible) {
 TEST_F(PointAttractorTest, PositionOnly) {
   current_pose.set_orientation(Eigen::Quaterniond::Identity());
   target_pose.set_orientation(Eigen::Quaterniond::Identity());
-  ds->set_parameter_value<CartesianState>("attractor", target_pose);
+  ds->set_parameter<CartesianState>("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -111,7 +111,7 @@ TEST_F(PointAttractorTest, PositionOnly) {
 TEST_F(PointAttractorTest, OrientationOnly) {
   current_pose.set_position(Eigen::Vector3d::Zero());
   target_pose.set_position(Eigen::Vector3d::Zero());
-  ds->set_parameter_value<CartesianState>("attractor", target_pose);
+  ds->set_parameter<CartesianState>("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -121,7 +121,7 @@ TEST_F(PointAttractorTest, OrientationOnly) {
 }
 
 TEST_F(PointAttractorTest, PositionAndOrientation) {
-  ds->set_parameter_value<CartesianState>("attractor", target_pose);
+  ds->set_parameter<CartesianState>("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -139,7 +139,7 @@ TEST_F(PointAttractorTest, FixedReferenceFrames) {
   CinA.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
   CinB.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
 
-  ds->set_parameter_value("attractor", BinA);
+  ds->set_parameter("attractor", BinA);
 
   // evaluating a current pose B in reference frame A should give zero twist (coincident with attractor)
   CartesianTwist twist = ds->evaluate(BinA);
@@ -159,7 +159,7 @@ TEST_F(PointAttractorTest, FixedReferenceFrames) {
 
 TEST_F(PointAttractorTest, UpdateBaseReferenceFrames) {
   auto BinA = CartesianState::Random("B", "A");
-  ds->set_parameter_value("attractor", BinA);
+  ds->set_parameter("attractor", BinA);
 
   // the base frame of the default constructed DS should be an identity frame
   // with the same name as the attractor reference frame
@@ -205,7 +205,7 @@ TEST_F(PointAttractorTest, StackedMovingReferenceFrames) {
   auto CinA = CartesianState::Identity("C", "A");
   CinA.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
 
-  ds->set_parameter_value("attractor", BinA);
+  ds->set_parameter("attractor", BinA);
 
   // evaluate the twist for a fixed state C in reference frame A
   CartesianTwist twist = ds->evaluate(CinA);
@@ -240,7 +240,7 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
   C = CartesianState::Random("C", "robot");
   D = CartesianState::Random("D", "robot");
 
-  ds->set_parameter_value("attractor", A);
+  ds->set_parameter("attractor", A);
 
   // state being evaluated must match the DS base frame, which is by default the attractor reference frame
   EXPECT_NO_THROW(ds->evaluate(B));
@@ -248,9 +248,9 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
 
   // setting the attractor to another point in the same base frame should be fine,
   // but setting it with a different base frame should give an error
-  EXPECT_NO_THROW(ds->set_parameter_value("attractor", B));
+  EXPECT_NO_THROW(ds->set_parameter("attractor", B));
   EXPECT_THROW(
-      ds->set_parameter_value("attractor", C), state_representation::exceptions::IncompatibleReferenceFramesException
+      ds->set_parameter("attractor", C), state_representation::exceptions::IncompatibleReferenceFramesException
   );
 
   // after updating the base frame, the attractor reference frame should also be updated
@@ -262,9 +262,9 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
 
   // with the new base frame, setting the attractor should succeed / fail accordingly
   EXPECT_THROW(
-      ds->set_parameter_value("attractor", B), state_representation::exceptions::IncompatibleReferenceFramesException
+      ds->set_parameter("attractor", B), state_representation::exceptions::IncompatibleReferenceFramesException
   );
-  EXPECT_NO_THROW(ds->set_parameter_value("attractor", C));
+  EXPECT_NO_THROW(ds->set_parameter("attractor", C));
 
   // now the evaluation should also succeed when matching the updated base frame
   EXPECT_THROW(ds->evaluate(B), state_representation::exceptions::IncompatibleReferenceFramesException);
@@ -279,7 +279,7 @@ TEST(JointPointAttractorTest, Constructor) {
   // base frame and attractor should be empty
   EXPECT_TRUE(ds->get_parameter_value<JointState>("attractor").is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
-  ds->set_parameter_value("attractor", attractor);
+  ds->set_parameter("attractor", attractor);
   EXPECT_FALSE(ds->get_parameter_value<JointState>("attractor").is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
 
@@ -299,7 +299,7 @@ TEST(JointPointAttractorTest, EmptyCompatible) {
 
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state2), dynamical_systems::exceptions::EmptyAttractorException);
-  ds->set_parameter_value("attractor", state1);
+  ds->set_parameter("attractor", state1);
 
   EXPECT_THROW(ds->evaluate(state2), state_representation::exceptions::EmptyStateException);
   EXPECT_THROW(ds->evaluate(state3), state_representation::exceptions::IncompatibleStatesException);
@@ -316,7 +316,7 @@ TEST(JointPointAttractorTest, Convergence) {
   auto current_state = JointPositions::Random("robot", 3);
   current_state.set_data(10 * current_state.data());
 
-  ds->set_parameter_value<JointState>("attractor", attractor);
+  ds->set_parameter<JointState>("attractor", attractor);
   for (unsigned int i = 0; i < 100; ++i) {
     JointVelocities velocities = ds->evaluate(current_state);
     current_state += 100ms * velocities;

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -38,7 +38,7 @@ TEST_F(RingDSTest, EmptyConstructor) {
   CartesianPose center = CartesianPose::Identity("CAttractor", "A");
   // base frame and attractor should be empty
   EXPECT_TRUE(ds->get_parameter_value<CartesianPose>("center").is_empty());
-  ds->set_parameter_value("center", center);
+  ds->set_parameter("center", center);
   EXPECT_FALSE(ds->get_parameter_value<CartesianPose>("center").is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -63,7 +63,7 @@ TEST_F(RingDSTest, EvaluateComptability) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter_value("center", center);
+  ds->set_parameter("center", center);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -71,10 +71,10 @@ TEST_F(RingDSTest, EvaluateComptability) {
 }
 
 TEST_F(RingDSTest, PointsOnRadius) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
-  ds->set_parameter_value("width", width);
-  ds->set_parameter_value("speed", speed);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
+  ds->set_parameter("width", width);
+  ds->set_parameter("speed", speed);
   CartesianTwist twist;
 
   // zero output at center
@@ -108,11 +108,11 @@ TEST_F(RingDSTest, PointsOnRadius) {
 }
 
 TEST_F(RingDSTest, PointsNearRadius) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
-  ds->set_parameter_value("width", width);
-  ds->set_parameter_value("speed", speed);
-  ds->set_parameter_value("field_strength", field_strength);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
+  ds->set_parameter("width", width);
+  ds->set_parameter("speed", speed);
+  ds->set_parameter("field_strength", field_strength);
   CartesianTwist twist;
 
   current_pose.set_position(radius + width, 0, 0);
@@ -142,11 +142,11 @@ TEST_F(RingDSTest, PointsNearRadius) {
 }
 
 TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", 1.0);
-  ds->set_parameter_value("width", 0.1);
-  ds->set_parameter_value("speed", 10.0);
-  ds->set_parameter_value("field_strength", 2.0);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", 1.0);
+  ds->set_parameter("width", 0.1);
+  ds->set_parameter("speed", 10.0);
+  ds->set_parameter("field_strength", 2.0);
   CartesianTwist twist;
 
   current_pose.set_position(0, radius + 1.001 * width, 0);
@@ -161,8 +161,8 @@ TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
 }
 
 TEST_F(RingDSTest, ConvergenceOnRadius) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -176,8 +176,8 @@ TEST_F(RingDSTest, ConvergenceOnRadius) {
 TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
   center.set_position(Eigen::Vector3d::Random());
   center.set_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -189,8 +189,8 @@ TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
 }
 
 TEST_F(RingDSTest, ZeroNormalGain) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("normal_gain", 0.0);
+  ds->set_parameter("center", center);
+  ds->set_parameter("normal_gain", 0.0);
 
   double startingHeight = current_pose.get_position().z();
   for (unsigned int i = 0; i < nb_steps; ++i) {
@@ -202,10 +202,10 @@ TEST_F(RingDSTest, ZeroNormalGain) {
 }
 
 TEST_F(RingDSTest, OrientationAroundCircle) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
-  ds->set_parameter_value("width", width);
-  ds->set_parameter_value("speed", 0.0);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
+  ds->set_parameter("width", width);
+  ds->set_parameter("speed", 0.0);
   CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null,
@@ -235,10 +235,10 @@ TEST_F(RingDSTest, OrientationAroundCircle) {
 }
 
 TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
-  ds->set_parameter_value("width", width);
-  ds->set_parameter_value("speed", 0.0);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
+  ds->set_parameter("width", width);
+  ds->set_parameter("speed", 0.0);
   CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null (angle around circle is 0)
@@ -267,10 +267,10 @@ TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
 }
 
 TEST_F(RingDSTest, OrientationRotationOffset) {
-  ds->set_parameter_value("center", center);
-  ds->set_parameter_value("radius", radius);
-  ds->set_parameter_value("width", width);
-  ds->set_parameter_value("speed", 0.0);
+  ds->set_parameter("center", center);
+  ds->set_parameter("radius", radius);
+  ds->set_parameter("width", width);
+  ds->set_parameter("speed", 0.0);
   CartesianTwist twist;
 
   current_pose.set_position(radius, 0, 0);
@@ -280,7 +280,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // if the rotation offset is the same as the current orientation, the angular velocity at
   // position {radius, 0, 0} is always zero
   current_pose.set_orientation(rotation);
-  ds->set_parameter_value("rotation_offset", current_pose);
+  ds->set_parameter("rotation_offset", current_pose);
   twist = ds->evaluate(current_pose);
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
 
@@ -298,17 +298,17 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // rotate the center plane in the base frame, and set the current position to have the same relative
   // offset that gives a zero command (no rotation offset)
   center.set_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter_value("center", center);
+  ds->set_parameter("center", center);
   current_pose = CartesianPose("B", Eigen::Vector3d(radius, 0, 0), "A");
   current_pose = center * current_pose;
-  ds->set_parameter_value("rotation_offset", CartesianPose::Identity("offset"));
+  ds->set_parameter("rotation_offset", CartesianPose::Identity("offset"));
   twist = ds->evaluate(current_pose);
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
 
   // for any rotation offset in a rotated center plane, the output will
   // still be zero if the current position and orientation matches the rotation offset
   rotation = Eigen::Quaterniond::UnitRandom();
-  ds->set_parameter_value("rotation_offset", CartesianPose("offset", rotation));
+  ds->set_parameter("rotation_offset", CartesianPose("offset", rotation));
   current_pose = CartesianPose(
       "B", Eigen::Vector3d(radius, 0, 0), ds->get_parameter_value<CartesianPose>("rotation_offset").get_orientation(),
       "A"
@@ -337,7 +337,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
 
 TEST_F(RingDSTest, BaseFrameBehaviours) {
   auto AinB = CartesianPose::Random("A", "B");
-  ds->set_parameter_value("center", AinB);
+  ds->set_parameter("center", AinB);
 
   // setting the center through the constructor should also set the base frame (as Identity frame)
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "A");
@@ -349,7 +349,7 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
   // setting the center should fail if it is incompatible with the base frame
   auto CinD = CartesianPose::Random("C", "D");
   EXPECT_THROW(
-      ds->set_parameter_value("center", CartesianPose(CinD)),
+      ds->set_parameter("center", CartesianPose(CinD)),
       state_representation::exceptions::IncompatibleReferenceFramesException
   );
 
@@ -365,30 +365,30 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
 
   // setting the center should succeed if it is expressed relative to the base frame
   auto BinC = CartesianPose::Random("B", "C");
-  EXPECT_NO_THROW(ds->set_parameter_value("center", BinC));
+  EXPECT_NO_THROW(ds->set_parameter("center", BinC));
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "B");
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_reference_frame().c_str(), "C");
 
   // setting the center should also succeed if it shares the same reference frame as the base frame
   auto BinD = CartesianPose::Random("B", "D");
-  EXPECT_NO_THROW(ds->set_parameter_value("center", BinD));
+  EXPECT_NO_THROW(ds->set_parameter("center", BinD));
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "B");
   // the reference frame is still C, not D, because the center is internally represented relative to the base frame (C)
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_reference_frame().c_str(), "C");
 }
 
 TEST_F(RingDSTest, SettersAndGetters) {
-  ds->set_parameter_value("center", center);
+  ds->set_parameter("center", center);
 
   auto pose = CartesianState::Random("C");
-  ds->set_parameter_value("center", CartesianPose(pose));
+  ds->set_parameter("center", CartesianPose(pose));
   auto pose2 = ds->get_parameter_value<CartesianPose>("center");
   EXPECT_STREQ(pose.get_name().c_str(), pose2.get_name().c_str());
   EXPECT_STREQ(pose.get_reference_frame().c_str(), pose2.get_reference_frame().c_str());
   EXPECT_NEAR(pose.get_pose().norm(), pose2.get_pose().norm(), tol);
 
   // all other setters should store the value
-  ds->set_parameter_value("rotation_offset", CartesianPose("offset", Eigen::Quaterniond(1, 2, 3, 4).normalized()));
+  ds->set_parameter("rotation_offset", CartesianPose("offset", Eigen::Quaterniond(1, 2, 3, 4).normalized()));
   EXPECT_NEAR(
       ds->get_parameter_value<CartesianPose>("rotation_offset")
           .get_orientation()
@@ -396,21 +396,21 @@ TEST_F(RingDSTest, SettersAndGetters) {
       0, tol
   );
 
-  ds->set_parameter_value("radius", 1.0);
+  ds->set_parameter("radius", 1.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("radius"), 1.0, tol);
 
-  ds->set_parameter_value("width", 2.0);
+  ds->set_parameter("width", 2.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("width"), 2.0, tol);
 
-  ds->set_parameter_value("speed", 3.0);
+  ds->set_parameter("speed", 3.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("speed"), 3.0, tol);
 
-  ds->set_parameter_value("field_strength", 4.0);
+  ds->set_parameter("field_strength", 4.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("field_strength"), 4.0, tol);
 
-  ds->set_parameter_value("normal_gain", 5.0);
+  ds->set_parameter("normal_gain", 5.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("normal_gain"), 5.0, tol);
 
-  ds->set_parameter_value("angular_gain", 6.0);
+  ds->set_parameter("angular_gain", 6.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("angular_gain"), 6.0, tol);
 }

--- a/source/state_representation/CMakeLists.txt
+++ b/source/state_representation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CORE_SOURCES
   src/parameters/Parameter.cpp
   src/parameters/ParameterInterface.cpp
   src/parameters/ParameterMap.cpp
+  src/parameters/StrictParameterMap.cpp
   src/parameters/Predicate.cpp
   src/geometry/Shape.cpp
   src/geometry/Ellipsoid.cpp

--- a/source/state_representation/include/state_representation/parameters/Parameter.hpp
+++ b/source/state_representation/include/state_representation/parameters/Parameter.hpp
@@ -215,4 +215,18 @@ static std::shared_ptr<Parameter<T>> make_shared_parameter(const std::string& na
       throw exceptions::InvalidParameterException("This ParameterType is not supported for parameters.");
   }
 }
+
+/**
+ * @brief Copy the value from one parameter to another through their ParameterInterface pointers
+ * @param source_parameter A pointer to the ParameterInterface of the parameter to copy from
+ * @param parameter A pointer to the ParameterInterface of the parameter to copy to
+ * @throw exceptions::InvalidParameterCastException if the ParameterInterface does not point to a valid Parameter 
+ * instance
+ * @throw exceptions::EmptyStateException if the source parameter is empty
+ * @throw exceptions::IncompatibleStatesException if the parameter type of the source and target parameters do not match
+ */
+[[maybe_unused]] void copy_parameter_value(
+    const std::shared_ptr<const ParameterInterface>& source_parameter,
+    const std::shared_ptr<ParameterInterface>& parameter
+);
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/parameters/Parameter.hpp
+++ b/source/state_representation/include/state_representation/parameters/Parameter.hpp
@@ -219,7 +219,7 @@ static std::shared_ptr<Parameter<T>> make_shared_parameter(const std::string& na
 /**
  * @brief Copy the value from one parameter to another through their ParameterInterface pointers
  * @param source_parameter A pointer to the ParameterInterface of the parameter to copy from
- * @param parameter A pointer to the ParameterInterface of the parameter to copy to
+ * @param target_parameter A pointer to the ParameterInterface of the parameter to copy to
  * @throw exceptions::InvalidParameterCastException if the ParameterInterface does not point to a valid Parameter 
  * instance
  * @throw exceptions::EmptyStateException if the source parameter is empty
@@ -227,6 +227,6 @@ static std::shared_ptr<Parameter<T>> make_shared_parameter(const std::string& na
  */
 [[maybe_unused]] void copy_parameter_value(
     const std::shared_ptr<const ParameterInterface>& source_parameter,
-    const std::shared_ptr<ParameterInterface>& parameter
+    const std::shared_ptr<ParameterInterface>& target_parameter
 );
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/parameters/ParameterInterface.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterInterface.hpp
@@ -57,28 +57,29 @@ public:
    * @param validate_pointer If true, throw an exception when downcasting fails
    * @return A pointer to a derived Parameter instance of the desired state type, or a null pointer
    * if downcasting failed and validate_pointer was set to false.
+   * @throw exceptions::InvalidParameterCastException if downcasting fails and validate_pointer is true
    */
   template<typename T>
   std::shared_ptr<Parameter<T>> get_parameter(bool validate_pointer = true) const;
 
   /**
    * @brief Get the parameter value of a derived Parameter instance through the ParameterInterface pointer.
-   * @details This throws an InvalidParameterCastException if the ParameterInterface does not point to
-   * a valid Parameter instance or if the specified type does not match the type of the Parameter instance.
    * @see ParameterInterface::get_parameter()
    * @tparam T The state type of the Parameter
    * @return The value contained in the underlying Parameter instance
+   * @throw exceptions::InvalidParameterCastException if the ParameterInterface does not point to
+   * a valid Parameter instance or if the specified type does not match the type of the Parameter instance.
    */
   template<typename T>
   T get_parameter_value() const;
 
   /**
    * @brief Set the parameter value of a derived Parameter instance through the ParameterInterface pointer.
-   * @details This throws an InvalidParameterCastException if the ParameterInterface does not point to
-   * a valid Parameter instance or if the specified type does not match the type of the Parameter instance.
    * @see ParameterInterface::get_parameter()
    * @tparam T The state type of the Parameter
    * @param value The value to set in the underlying Parameter instance
+   * @throw exceptions::InvalidParameterCastException if the ParameterInterface does not point to
+   * a valid Parameter instance or if the specified type does not match the type of the Parameter instance.
    */
   template<typename T>
   void set_parameter_value(const T& value);

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -91,15 +91,6 @@ public:
   void set_parameters(const ParameterInterfaceMap& parameters);
 
   /**
-   * @brief Set a parameter value by its name.
-   * @tparam T Type of the parameter value
-   * @param name The name of the parameter
-   * @param value The new value of the parameter
-   */
-  template<typename T>
-  [[deprecated]] void set_parameter_value(const std::string& name, const T& value);
-
-  /**
    * @brief Remove a parameter from the parameter map.
    * @param name The name of the parameter that should be removed
    * @raise InvalidParameterException if the parameter does not exist
@@ -128,11 +119,6 @@ protected:
 template<typename T>
 inline T ParameterMap::get_parameter_value(const std::string& name) const {
   return this->get_parameter(name)->get_parameter_value<T>();
-}
-
-template<typename T>
-inline void ParameterMap::set_parameter_value(const std::string& name, const T& value) {
-  this->validate_and_set_parameter(make_shared_parameter<T>(name, value));
 }
 
 template<typename T>

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -70,7 +70,8 @@ public:
   void set_parameter(const std::shared_ptr<ParameterInterface>& parameter);
 
   /**
-   * @brief Set a parameter value by its name.
+   * @brief Set a parameter by name and value.
+   * @details If a parameter by the same name already exists in the parameter map, it will be overwritten and any existing ParameterInterface pointer references will be invalidated. Consumers should call get_parameter() or get_parameters() after calling this method to update any references.
    * @tparam T Type of the parameter value
    * @param name The name of the parameter
    * @param value The new value of the parameter

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -71,7 +71,9 @@ public:
 
   /**
    * @brief Set a parameter by name and value.
-   * @details If a parameter by the same name already exists in the parameter map, it will be overwritten and any existing ParameterInterface pointer references will be invalidated. Consumers should call get_parameter() or get_parameters() after calling this method to update any references.
+   * @details If a parameter by the same name already exists in the parameter map, it will be overwritten and any
+   * existing ParameterInterface pointer references will be invalidated. Consumers should call get_parameter() or
+   * get_parameters() after calling this method to update any references.
    * @tparam T Type of the parameter value
    * @param name The name of the parameter
    * @param value The new value of the parameter
@@ -94,7 +96,7 @@ public:
   /**
    * @brief Remove a parameter from the parameter map.
    * @param name The name of the parameter that should be removed
-   * @raise InvalidParameterException if the parameter does not exist
+   * @throw InvalidParameterException if the parameter does not exist
    */
   void remove_parameter(const std::string& name);
 

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -31,7 +31,7 @@ public:
 
   /**
    * @brief Construct the parameter map with an initial map of parameters
-   * @param parameters A amp of Parameter pointers
+   * @param parameters A map of Parameter pointers
    */
   explicit ParameterMap(const ParameterInterfaceMap& parameters);
 
@@ -70,6 +70,15 @@ public:
   void set_parameter(const std::shared_ptr<ParameterInterface>& parameter);
 
   /**
+   * @brief Set a parameter value by its name.
+   * @tparam T Type of the parameter value
+   * @param name The name of the parameter
+   * @param value The new value of the parameter
+   */
+  template<typename T>
+  void set_parameter(const std::string& name, const T& value);
+
+  /**
    * @brief Set parameters from a list of parameters.
    * @param parameters The list of parameters
    */
@@ -88,7 +97,7 @@ public:
    * @param value The new value of the parameter
    */
   template<typename T>
-  void set_parameter_value(const std::string& name, const T& value);
+  [[deprecated]] void set_parameter_value(const std::string& name, const T& value);
 
   /**
    * @brief Remove a parameter from the parameter map.
@@ -123,6 +132,11 @@ inline T ParameterMap::get_parameter_value(const std::string& name) const {
 
 template<typename T>
 inline void ParameterMap::set_parameter_value(const std::string& name, const T& value) {
+  this->validate_and_set_parameter(make_shared_parameter<T>(name, value));
+}
+
+template<typename T>
+inline void ParameterMap::set_parameter(const std::string& name, const T& value) {
   this->validate_and_set_parameter(make_shared_parameter<T>(name, value));
 }
 

--- a/source/state_representation/include/state_representation/parameters/StrictParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/StrictParameterMap.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "state_representation/parameters/ParameterMap.hpp"
+
+namespace state_representation {
+
+/**
+ * @class StrictParameterMap
+ * @brief A strict version of ParameterMap that enforces type safety for parameters.
+ */
+class StrictParameterMap : public ParameterMap {
+public:
+  /**
+   * @brief Empty constructor
+   */
+  StrictParameterMap() = default;
+
+  /**
+   * @brief Construct the parameter map with an initial list of parameters
+   * @param parameters A list of Parameter pointers
+   */
+  explicit StrictParameterMap(const ParameterInterfaceList& parameters);
+
+  /**
+   * @brief Construct the parameter map with an initial map of parameters
+   * @param parameters A map of Parameter pointers
+   */
+  explicit StrictParameterMap(const ParameterInterfaceMap& parameters);
+
+protected:
+  /**
+   * @brief Validate and set a parameter in the map.
+   * @param parameter The parameter to be validated
+   */
+  void validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) override;
+};
+
+}// namespace state_representation

--- a/source/state_representation/include/state_representation/parameters/StrictParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/StrictParameterMap.hpp
@@ -30,7 +30,9 @@ public:
 protected:
   /**
    * @brief Validate and set a parameter in the map.
-   * @param parameter The parameter to be validated
+   * @param parameter The parameter to be validated and set in the map.
+   * @throw exceptions::InvalidParameterException if a parameter with the same name already exists in the map but has
+   * a different type or state type than the provided parameter.
    */
   void validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) override;
 };

--- a/source/state_representation/src/parameters/Parameter.cpp
+++ b/source/state_representation/src/parameters/Parameter.cpp
@@ -1,5 +1,10 @@
 #include "state_representation/parameters/Parameter.hpp"
 
+#include "state_representation/exceptions/IncompatibleStatesException.hpp"
+#include "state_representation/space/cartesian/CartesianPose.hpp"
+#include "state_representation/space/joint/JointPositions.hpp"
+
+
 namespace state_representation {
 
 template<>
@@ -220,5 +225,86 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<std::stri
     os << "]";
   }
   return os;
+}
+
+void copy_parameter_value(
+    const std::shared_ptr<const ParameterInterface>& source_parameter,
+    const std::shared_ptr<ParameterInterface>& parameter
+) {
+  if (parameter->get_parameter_type() != source_parameter->get_parameter_type()) {
+    throw exceptions::IncompatibleStatesException(
+        "Source parameter " + source_parameter->get_name()
+        + " to be copied does not have the same type as destination parameter " + parameter->get_name() + "("
+        + get_parameter_type_name(source_parameter->get_parameter_type()) + " vs. "
+        + get_parameter_type_name(parameter->get_parameter_type()) + ")"
+    );
+  }
+  switch (parameter->get_parameter_type()) {
+    case ParameterType::BOOL:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<bool>());
+      return;
+    case ParameterType::BOOL_ARRAY:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<bool>>());
+      return;
+    case ParameterType::INT:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<int>());
+      return;
+    case ParameterType::INT_ARRAY:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<int>>());
+      return;
+    case ParameterType::DOUBLE:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<double>());
+      return;
+    case ParameterType::DOUBLE_ARRAY:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<double>>());
+      return;
+    case ParameterType::STRING:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<std::string>());
+      return;
+    case ParameterType::STRING_ARRAY:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<std::string>>());
+      return;
+    case ParameterType::VECTOR:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::VectorXd>());
+      return;
+    case ParameterType::MATRIX:
+      parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::MatrixXd>());
+      return;
+    case ParameterType::STATE:
+      if (parameter->get_parameter_state_type() != source_parameter->get_parameter_state_type()) {
+        throw exceptions::IncompatibleStatesException(
+            "Source parameter " + source_parameter->get_name()
+            + " to be copied does not have the same parameter state type as destination parameter "
+            + parameter->get_name() + "(" + get_state_type_name(source_parameter->get_parameter_state_type()) + " vs. "
+            + get_state_type_name(parameter->get_parameter_state_type()) + ")"
+        );
+      }
+      switch (parameter->get_parameter_state_type()) {
+        case StateType::CARTESIAN_STATE:
+          parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianState>());
+          return;
+        case StateType::CARTESIAN_POSE:
+          parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianPose>());
+          return;
+        case StateType::JOINT_STATE:
+          parameter->set_parameter_value(source_parameter->get_parameter_value<JointState>());
+          return;
+        case StateType::JOINT_POSITIONS:
+          parameter->set_parameter_value(source_parameter->get_parameter_value<JointPositions>());
+          return;
+        case StateType::GEOMETRY_ELLIPSOID:
+          parameter->set_parameter_value(source_parameter->get_parameter_value<Ellipsoid>());
+          return;
+        default:
+          break;
+      }
+      break;
+    default:
+      break;
+  }
+  throw exceptions::IncompatibleStatesException(
+      "Could not copy the value from source parameter " + source_parameter->get_name() + " into parameter "
+      + parameter->get_name()
+  );
 }
 }// namespace state_representation

--- a/source/state_representation/src/parameters/Parameter.cpp
+++ b/source/state_representation/src/parameters/Parameter.cpp
@@ -229,71 +229,71 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<std::stri
 
 void copy_parameter_value(
     const std::shared_ptr<const ParameterInterface>& source_parameter,
-    const std::shared_ptr<ParameterInterface>& parameter
+    const std::shared_ptr<ParameterInterface>& target_parameter
 ) {
-  if (parameter->get_parameter_type() != source_parameter->get_parameter_type()) {
+  if (target_parameter->get_parameter_type() != source_parameter->get_parameter_type()) {
     throw exceptions::IncompatibleStatesException(
         "Source parameter " + source_parameter->get_name()
-        + " to be copied does not have the same type as destination parameter " + parameter->get_name() + "("
+        + " to be copied does not have the same type as target parameter " + target_parameter->get_name() + "("
         + get_parameter_type_name(source_parameter->get_parameter_type()) + " vs. "
-        + get_parameter_type_name(parameter->get_parameter_type()) + ")"
+        + get_parameter_type_name(target_parameter->get_parameter_type()) + ")"
     );
   }
-  switch (parameter->get_parameter_type()) {
+  switch (target_parameter->get_parameter_type()) {
     case ParameterType::BOOL:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<bool>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<bool>());
       return;
     case ParameterType::BOOL_ARRAY:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<bool>>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<bool>>());
       return;
     case ParameterType::INT:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<int>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<int>());
       return;
     case ParameterType::INT_ARRAY:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<int>>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<int>>());
       return;
     case ParameterType::DOUBLE:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<double>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<double>());
       return;
     case ParameterType::DOUBLE_ARRAY:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<double>>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<double>>());
       return;
     case ParameterType::STRING:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<std::string>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<std::string>());
       return;
     case ParameterType::STRING_ARRAY:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<std::string>>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<std::vector<std::string>>());
       return;
     case ParameterType::VECTOR:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::VectorXd>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::VectorXd>());
       return;
     case ParameterType::MATRIX:
-      parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::MatrixXd>());
+      target_parameter->set_parameter_value(source_parameter->get_parameter_value<Eigen::MatrixXd>());
       return;
     case ParameterType::STATE:
-      if (parameter->get_parameter_state_type() != source_parameter->get_parameter_state_type()) {
+      if (target_parameter->get_parameter_state_type() != source_parameter->get_parameter_state_type()) {
         throw exceptions::IncompatibleStatesException(
             "Source parameter " + source_parameter->get_name()
-            + " to be copied does not have the same parameter state type as destination parameter "
-            + parameter->get_name() + "(" + get_state_type_name(source_parameter->get_parameter_state_type()) + " vs. "
-            + get_state_type_name(parameter->get_parameter_state_type()) + ")"
+            + " to be copied does not have the same parameter state type as target parameter "
+            + target_parameter->get_name() + "(" + get_state_type_name(source_parameter->get_parameter_state_type())
+            + " vs. " + get_state_type_name(target_parameter->get_parameter_state_type()) + ")"
         );
       }
-      switch (parameter->get_parameter_state_type()) {
+      switch (target_parameter->get_parameter_state_type()) {
         case StateType::CARTESIAN_STATE:
-          parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianState>());
+          target_parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianState>());
           return;
         case StateType::CARTESIAN_POSE:
-          parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianPose>());
+          target_parameter->set_parameter_value(source_parameter->get_parameter_value<CartesianPose>());
           return;
         case StateType::JOINT_STATE:
-          parameter->set_parameter_value(source_parameter->get_parameter_value<JointState>());
+          target_parameter->set_parameter_value(source_parameter->get_parameter_value<JointState>());
           return;
         case StateType::JOINT_POSITIONS:
-          parameter->set_parameter_value(source_parameter->get_parameter_value<JointPositions>());
+          target_parameter->set_parameter_value(source_parameter->get_parameter_value<JointPositions>());
           return;
         case StateType::GEOMETRY_ELLIPSOID:
-          parameter->set_parameter_value(source_parameter->get_parameter_value<Ellipsoid>());
+          target_parameter->set_parameter_value(source_parameter->get_parameter_value<Ellipsoid>());
           return;
         default:
           break;
@@ -303,8 +303,8 @@ void copy_parameter_value(
       break;
   }
   throw exceptions::IncompatibleStatesException(
-      "Could not copy the value from source parameter " + source_parameter->get_name() + " into parameter "
-      + parameter->get_name()
+      "Could not copy the value from source parameter " + source_parameter->get_name() + " into target parameter "
+      + target_parameter->get_name()
   );
 }
 }// namespace state_representation

--- a/source/state_representation/src/parameters/ParameterMap.cpp
+++ b/source/state_representation/src/parameters/ParameterMap.cpp
@@ -65,6 +65,9 @@ void ParameterMap::assert_parameter_valid(const std::shared_ptr<ParameterInterfa
 }
 
 void ParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
+  if (this->parameters_.count(parameter->get_name())) {
+    this->parameters_.at(parameter->get_name()).reset();
+  }
   this->parameters_.insert_or_assign(parameter->get_name(), parameter);
 }
 

--- a/source/state_representation/src/parameters/ParameterMap.cpp
+++ b/source/state_representation/src/parameters/ParameterMap.cpp
@@ -65,7 +65,7 @@ void ParameterMap::assert_parameter_valid(const std::shared_ptr<ParameterInterfa
 }
 
 void ParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
-  if (this->parameters_.count(parameter->get_name())) {
+  if (this->parameters_.find(parameter->get_name()) != this->parameters_.cend()) {
     this->parameters_.at(parameter->get_name())->reset();
   }
   this->parameters_.insert_or_assign(parameter->get_name(), parameter);

--- a/source/state_representation/src/parameters/ParameterMap.cpp
+++ b/source/state_representation/src/parameters/ParameterMap.cpp
@@ -66,7 +66,7 @@ void ParameterMap::assert_parameter_valid(const std::shared_ptr<ParameterInterfa
 
 void ParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
   if (this->parameters_.count(parameter->get_name())) {
-    this->parameters_.at(parameter->get_name()).reset();
+    this->parameters_.at(parameter->get_name())->reset();
   }
   this->parameters_.insert_or_assign(parameter->get_name(), parameter);
 }

--- a/source/state_representation/src/parameters/StrictParameterMap.cpp
+++ b/source/state_representation/src/parameters/StrictParameterMap.cpp
@@ -1,0 +1,15 @@
+#include "state_representation/parameters/StrictParameterMap.hpp"
+
+namespace state_representation {
+
+StrictParameterMap::StrictParameterMap(const ParameterInterfaceList& parameters) : ParameterMap(parameters) {}
+
+StrictParameterMap::StrictParameterMap(const ParameterInterfaceMap& parameters) : ParameterMap(parameters) {}
+void StrictParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
+  if (this->parameters_.find(parameter->get_name()) != this->parameters_.end()) {
+    this->assert_parameter_valid(parameter);
+  }
+  this->parameters_.insert_or_assign(parameter->get_name(), parameter);
+}
+
+}// namespace state_representation

--- a/source/state_representation/src/parameters/StrictParameterMap.cpp
+++ b/source/state_representation/src/parameters/StrictParameterMap.cpp
@@ -10,6 +10,7 @@ void StrictParameterMap::validate_and_set_parameter(const std::shared_ptr<Parame
   if (auto param_it = this->parameters_.find(parameter->get_name()); param_it != this->parameters_.cend()) {
     try {
       copy_parameter_value(parameter, param_it->second);
+      return;
     } catch (const std::exception& ex) {
       throw exceptions::InvalidParameterException(ex.what());
     }

--- a/source/state_representation/src/parameters/StrictParameterMap.cpp
+++ b/source/state_representation/src/parameters/StrictParameterMap.cpp
@@ -5,11 +5,16 @@ namespace state_representation {
 StrictParameterMap::StrictParameterMap(const ParameterInterfaceList& parameters) : ParameterMap(parameters) {}
 
 StrictParameterMap::StrictParameterMap(const ParameterInterfaceMap& parameters) : ParameterMap(parameters) {}
+
 void StrictParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
-  if (this->parameters_.find(parameter->get_name()) != this->parameters_.cend()) {
-    this->assert_parameter_valid(parameter);
+  if (auto param_it = this->parameters_.find(parameter->get_name()); param_it != this->parameters_.cend()) {
+    try {
+      copy_parameter_value(parameter, param_it->second);
+    } catch (const std::exception& ex) {
+      throw exceptions::InvalidParameterException(ex.what());
+    }
   }
-  this->parameters_.insert_or_assign(parameter->get_name(), parameter);
+  this->parameters_.insert({parameter->get_name(), parameter});
 }
 
 }// namespace state_representation

--- a/source/state_representation/src/parameters/StrictParameterMap.cpp
+++ b/source/state_representation/src/parameters/StrictParameterMap.cpp
@@ -6,7 +6,7 @@ StrictParameterMap::StrictParameterMap(const ParameterInterfaceList& parameters)
 
 StrictParameterMap::StrictParameterMap(const ParameterInterfaceMap& parameters) : ParameterMap(parameters) {}
 void StrictParameterMap::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
-  if (this->parameters_.find(parameter->get_name()) != this->parameters_.end()) {
+  if (this->parameters_.find(parameter->get_name()) != this->parameters_.cend()) {
     this->assert_parameter_valid(parameter);
   }
   this->parameters_.insert_or_assign(parameter->get_name(), parameter);

--- a/source/state_representation/test/tests/test_parameter.cpp
+++ b/source/state_representation/test/tests/test_parameter.cpp
@@ -246,9 +246,14 @@ TYPED_TEST_P(ParameterTest, MakeShared) {
     EXPECT_EQ(param->get_parameter_type(), std::get<1>(test_case));
     EXPECT_EQ(param->get_parameter_state_type(), std::get<2>(test_case));
     expect_values_equal(param->get_value(), std::get<0>(test_case));
+    copy_parameter_value(param, param_interface);
+    expect_values_equal(param_interface->template get_parameter_value<TypeParam>(), std::get<0>(test_case));
+  
     auto empty_param = make_shared_parameter<TypeParam>("test");
     EXPECT_TRUE(empty_param->is_empty());
     EXPECT_FALSE(*empty_param);
+
+    EXPECT_THROW(copy_parameter_value(empty_param, param_interface), exceptions::EmptyStateException);
   }
 }
 

--- a/source/state_representation/test/tests/test_parameter_map.cpp
+++ b/source/state_representation/test/tests/test_parameter_map.cpp
@@ -3,6 +3,7 @@
 #include "state_representation/exceptions/InvalidParameterException.hpp"
 #include "state_representation/parameters/Parameter.hpp"
 #include "state_representation/parameters/ParameterMap.hpp"
+#include "state_representation/parameters/StrictParameterMap.hpp"
 
 using namespace state_representation;
 
@@ -31,7 +32,7 @@ TEST(ParameterMapTest, ValidateSetParameter) {
   EXPECT_NO_THROW(value = map.get_parameter_value<int>("int"));
   EXPECT_EQ(1, value);
   map.validate_called = false;
-  map.set_parameter_value<int>("int", 2);
+  map.set_parameter<int>("int", 2);
   EXPECT_TRUE(map.validate_called);
   EXPECT_NO_THROW(value = map.get_parameter("int")->get_parameter_value<int>());
   EXPECT_EQ(2, value);
@@ -55,4 +56,11 @@ TEST(ParameterMapTest, AssertParameterValid) {
       map.assert_parameter_valid(make_shared_parameter("joint", CartesianState::Random("test"))),
       exceptions::InvalidParameterException
   );
+}
+
+TEST(ParameterMapTest, StrictParameterMap) {
+  StrictParameterMap map;
+  EXPECT_NO_THROW(map.set_parameter(make_shared_parameter("int", 1)));
+  EXPECT_NO_THROW(map.set_parameter<int>("int", 2));
+  EXPECT_THROW(map.set_parameter(make_shared_parameter("int", 1.0)), exceptions::InvalidParameterException);
 }


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #259 

<!-- Required: explain how the PR addresses the parent issue -->
This PR is breaking (right?) since we are changing the vtable of the class with an additional templated class. So we could technically directly remove the `set_parameter_value`.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->